### PR TITLE
Avoid recursive locking

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 8203ae3818bed4bfea20fc5cfae4f7bc1b05b35e0cf174b35a828b4d0af428fd
-updated: 2018-05-14T18:06:01.41726-04:00
+hash: 9f30161cb618210a846b8d99b66f0d8e3330f0f07b25db4440318a40ea14ffb5
+updated: 2018-05-16T17:17:39.826533-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -41,7 +41,7 @@ imports:
   - services/leader/campaign
   - shard
 - name: github.com/m3db/m3x
-  version: 012300c4fbb8a23f328832c216e2c2458dbbea94
+  version: 56f61c31a12f10712dc69fb70980f4361a499c77
   subpackages:
   - checked
   - clock

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/m3db/m3msg
 import:
 - package: github.com/m3db/m3x
-  version: 012300c4fbb8a23f328832c216e2c2458dbbea94
+  version: 56f61c31a12f10712dc69fb70980f4361a499c77
 - package: github.com/m3db/m3cluster
   version: cb17a54d6902c03790286942bafa04a188d4eeb8
 - package: github.com/golang/protobuf

--- a/integration/setup.go
+++ b/integration/setup.go
@@ -50,8 +50,8 @@ import (
 const (
 	numConcurrentMessages = 10
 	numberOfShards        = 10
-	msgPerShard           = 100
-	closeTimeout          = 60 * time.Second
+	msgPerShard           = 50
+	closeTimeout          = 30 * time.Second
 )
 
 type consumerServiceConfig struct {
@@ -216,8 +216,9 @@ func (s setup) CloseProducers(dur time.Duration) {
 
 	select {
 	case <-time.After(dur):
-		panic("taking too long to close producers")
+		panic(fmt.Sprintf("taking more than %v to close producers %v", dur, time.Now()))
 	case <-doneCh:
+		log.SimpleLogger.Debugf("producer closed in %v", dur)
 		return
 	}
 }
@@ -480,20 +481,20 @@ writer:
   messagePool:
     size: 1
   messageRetry:
-    initialBackoff: 100ms
-    maxBackoff: 500ms
-  messageQueueScanInterval: 100ms
+    initialBackoff: 10ms
+    maxBackoff: 50ms
+  messageQueueScanInterval: 10ms
   closeCheckInterval: 100ms
   ackErrorRetry: 
-    initialBackoff: 100ms
-    maxBackoff: 500ms
+    initialBackoff: 10ms
+    maxBackoff: 50ms
   connection:
     dialTimeout: 500ms
     retry:
-      initialBackoff: 100ms
-      maxBackoff: 500ms
+      initialBackoff: 10ms
+      maxBackoff: 50ms
     writeBufferSize: 1
-    resetDelay: 100ms
+    resetDelay: 50ms
 `
 
 	var cfg config.ProducerConfiguration

--- a/integration/setup.go
+++ b/integration/setup.go
@@ -50,7 +50,7 @@ import (
 const (
 	numConcurrentMessages = 10
 	numberOfShards        = 10
-	msgPerShard           = 50
+	msgPerShard           = 200
 	closeTimeout          = 30 * time.Second
 )
 

--- a/producer/data/ref_counted.go
+++ b/producer/data/ref_counted.go
@@ -95,10 +95,11 @@ func (d *refCountedData) IsDroppedOrConsumed() bool {
 
 func (d *refCountedData) finalize(r producer.FinalizeReason) bool {
 	d.Lock()
-	if !d.isDroppedOrConsumed.CAS(false, true) {
+	if d.isDroppedOrConsumed.Load() {
 		d.Unlock()
 		return false
 	}
+	d.isDroppedOrConsumed.Store(true)
 	d.Unlock()
 	if d.onFinalizeFn != nil {
 		d.onFinalizeFn(d)

--- a/producer/data/ref_counted.go
+++ b/producer/data/ref_counted.go
@@ -38,7 +38,7 @@ type refCountedData struct {
 	onFinalizeFn OnFinalizeFn
 
 	refCount            *atomic.Int32
-	isDroppedOrConsumed bool
+	isDroppedOrConsumed *atomic.Bool
 }
 
 // NewRefCountedData creates RefCountedData.
@@ -47,7 +47,7 @@ func NewRefCountedData(data producer.Data, fn OnFinalizeFn) producer.RefCountedD
 		Data:                data,
 		refCount:            atomic.NewInt32(0),
 		onFinalizeFn:        fn,
-		isDroppedOrConsumed: false,
+		isDroppedOrConsumed: atomic.NewBool(false),
 	}
 }
 
@@ -90,19 +90,15 @@ func (d *refCountedData) Drop() bool {
 }
 
 func (d *refCountedData) IsDroppedOrConsumed() bool {
-	d.RLock()
-	r := d.isDroppedOrConsumed
-	d.RUnlock()
-	return r
+	return d.isDroppedOrConsumed.Load()
 }
 
 func (d *refCountedData) finalize(r producer.FinalizeReason) bool {
 	d.Lock()
-	if d.isDroppedOrConsumed {
+	if !d.isDroppedOrConsumed.CAS(false, true) {
 		d.Unlock()
 		return false
 	}
-	d.isDroppedOrConsumed = true
 	d.Unlock()
 	if d.onFinalizeFn != nil {
 		d.onFinalizeFn(d)

--- a/producer/writer/message.go
+++ b/producer/writer/message.go
@@ -83,8 +83,8 @@ func (m *message) IsDroppedOrAcked() bool {
 
 // Ack acknowledges the message. Duplicated acks on the same message might cause panic.
 func (m *message) Ack() {
-	m.RefCountedData.DecRef()
 	m.isAcked.Store(true)
+	m.RefCountedData.DecRef()
 }
 
 // Metadata returns the metadata.


### PR DESCRIPTION
When thread1 has the RLock and thread2 requests to acquire the WLock, Go does not allow any thread including thread1 to acquire RLock again. This pr fixes that recursive locking issue.

@xichen2020 