### PR TITLE
Add consumer server

### DIFF
--- a/consumer/consumer_test.go
+++ b/consumer/consumer_test.go
@@ -317,6 +317,7 @@ func TestConsumerAckAfterClosed(t *testing.T) {
 	// Second ack will not trigger encode since the consumer is closed.
 	m2.Ack()
 }
+
 func TestConsumerFlushAcksOnClose(t *testing.T) {
 	defer leaktest.Check(t)()
 

--- a/consumer/options.go
+++ b/consumer/options.go
@@ -114,7 +114,7 @@ func (opts *options) SetInstrumentOptions(value instrument.Options) Options {
 }
 
 type serverOptions struct {
-	messageFn MessageFn
+	consumeFn ConsumeFn
 	sOpts     server.Options
 	cOpts     Options
 }
@@ -126,13 +126,14 @@ func NewServerOptions() ServerOptions {
 		cOpts: NewOptions(),
 	}
 }
-func (opts *serverOptions) MessageFn() MessageFn {
-	return opts.messageFn
+
+func (opts *serverOptions) ConsumeFn() ConsumeFn {
+	return opts.consumeFn
 }
 
-func (opts *serverOptions) SetMessageFn(value MessageFn) ServerOptions {
+func (opts *serverOptions) SetConsumeFn(value ConsumeFn) ServerOptions {
 	o := *opts
-	o.messageFn = value
+	o.consumeFn = value
 	return &o
 }
 

--- a/consumer/options.go
+++ b/consumer/options.go
@@ -22,7 +22,9 @@ package consumer
 
 import (
 	"github.com/m3db/m3msg/protocol/proto"
+	"github.com/m3db/m3x/instrument"
 	"github.com/m3db/m3x/pool"
+	"github.com/m3db/m3x/server"
 )
 
 var (
@@ -36,6 +38,7 @@ type options struct {
 	ackBufferSize   int
 	writeBufferSize int
 	readBufferSize  int
+	iOpts           instrument.Options
 }
 
 // NewOptions creates a new options.
@@ -46,6 +49,7 @@ func NewOptions() Options {
 		ackBufferSize:   defaultAckBufferSize,
 		writeBufferSize: defaultConnectionBufferSize,
 		readBufferSize:  defaultConnectionBufferSize,
+		iOpts:           instrument.NewOptions(),
 	}
 }
 
@@ -96,5 +100,58 @@ func (opts *options) ConnectionReadBufferSize() int {
 func (opts *options) SetConnectionReadBufferSize(value int) Options {
 	o := *opts
 	o.readBufferSize = value
+	return &o
+}
+
+func (opts *options) InstrumentOptions() instrument.Options {
+	return opts.iOpts
+}
+
+func (opts *options) SetInstrumentOptions(value instrument.Options) Options {
+	o := *opts
+	o.iOpts = value
+	return &o
+}
+
+type serverOptions struct {
+	messageFn MessageFn
+	sOpts     server.Options
+	cOpts     Options
+}
+
+// NewServerOptions creates ServerOptions.
+func NewServerOptions() ServerOptions {
+	return &serverOptions{
+		sOpts: server.NewOptions(),
+		cOpts: NewOptions(),
+	}
+}
+func (opts *serverOptions) MessageFn() MessageFn {
+	return opts.messageFn
+}
+
+func (opts *serverOptions) SetMessageFn(value MessageFn) ServerOptions {
+	o := *opts
+	o.messageFn = value
+	return &o
+}
+
+func (opts *serverOptions) ServerOptions() server.Options {
+	return opts.sOpts
+}
+
+func (opts *serverOptions) SetServerOptions(value server.Options) ServerOptions {
+	o := *opts
+	o.sOpts = value
+	return &o
+}
+
+func (opts *serverOptions) ConsumerOptions() Options {
+	return opts.cOpts
+}
+
+func (opts *serverOptions) SetConsumerOptions(value Options) ServerOptions {
+	o := *opts
+	o.cOpts = value
 	return &o
 }

--- a/consumer/server.go
+++ b/consumer/server.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package consumer
+
+import (
+	"net"
+
+	"github.com/m3db/m3x/server"
+
+	"go.uber.org/atomic"
+)
+
+// NewServer creates a new server.
+func NewServer(addr string, opts ServerOptions) (server.Server, error) {
+	return server.NewServer(
+		addr,
+		newHandler(opts.MessageFn(), opts.ConsumerOptions()),
+		opts.ServerOptions(),
+	), nil
+}
+
+type handler struct {
+	messageFn MessageFn
+	opts      Options
+	mPool     *messagePool
+
+	closed *atomic.Bool
+	doneCh chan struct{}
+	m      metrics
+}
+
+func newHandler(messageFn MessageFn, opts Options) *handler {
+	mPool := newMessagePool(opts.MessagePoolOptions())
+	mPool.Init()
+	return &handler{
+		messageFn: messageFn,
+		opts:      opts,
+		mPool:     mPool,
+		closed:    atomic.NewBool(false),
+		doneCh:    make(chan struct{}),
+		m:         newConsumerMetrics(opts.InstrumentOptions().MetricsScope()),
+	}
+}
+
+func (h *handler) Handle(conn net.Conn) {
+	if h.closed.Load() {
+		return
+	}
+	c := newConsumer(conn, h.mPool, h.opts, h.m)
+	for {
+		select {
+		case <-h.doneCh:
+			c.Close()
+			return
+		default:
+			msg, err := c.Message()
+			if err != nil {
+				c.Close()
+				return
+			}
+			h.messageFn(msg)
+		}
+	}
+}
+
+func (h *handler) Close() {
+	if !h.closed.CAS(false, true) {
+		return
+	}
+	close(h.doneCh)
+}

--- a/consumer/server.go
+++ b/consumer/server.go
@@ -27,12 +27,12 @@ import (
 )
 
 // NewServer creates a new server.
-func NewServer(addr string, opts ServerOptions) (server.Server, error) {
+func NewServer(addr string, opts ServerOptions) server.Server {
 	return server.NewServer(
 		addr,
 		newHandler(opts.ConsumeFn(), opts.ConsumerOptions()),
 		opts.ServerOptions(),
-	), nil
+	)
 }
 
 type handler struct {

--- a/consumer/server_test.go
+++ b/consumer/server_test.go
@@ -60,9 +60,7 @@ func TestConsumerServer(t *testing.T) {
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
-	s, err := NewServer("a", opts)
-	require.NoError(t, err)
-
+	s := NewServer("a", opts)
 	s.Serve(l)
 
 	conn, err := net.Dial("tcp", l.Addr().String())

--- a/consumer/server_test.go
+++ b/consumer/server_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package consumer
+
+import (
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/m3db/m3msg/generated/proto/msgpb"
+	"github.com/m3db/m3msg/protocol/proto"
+
+	"github.com/fortytw2/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConsumerServer(t *testing.T) {
+	defer leaktest.Check(t)()
+
+	var (
+		count = 0
+		bytes []byte
+		wg    sync.WaitGroup
+	)
+	wg.Add(1)
+	messageFn := func(m Message) {
+		count++
+		bytes = m.Bytes()
+		m.Ack()
+		wg.Done()
+	}
+
+	opts := NewServerOptions().SetConsumerOptions(testOptions()).SetMessageFn(messageFn)
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	s, err := NewServer("a", opts)
+	require.NoError(t, err)
+
+	s.Serve(l)
+
+	conn, err := net.Dial("tcp", l.Addr().String())
+	require.NoError(t, err)
+
+	producer := proto.NewEncodeDecoder(conn, opts.ConsumerOptions().EncodeDecoderOptions())
+	err = producer.Encode(&testMsg1)
+	require.NoError(t, err)
+
+	wg.Wait()
+	require.Equal(t, testMsg1.Value, bytes)
+
+	var ack msgpb.Ack
+	err = producer.Decode(&ack)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(ack.Metadata))
+	require.Equal(t, testMsg1.Metadata, ack.Metadata[0])
+
+	s.Close()
+	s.Close()
+
+	_, err = net.Dial("tcp", l.Addr().String())
+	require.Error(t, err)
+}

--- a/consumer/types.go
+++ b/consumer/types.go
@@ -99,16 +99,16 @@ type Options interface {
 	SetInstrumentOptions(value instrument.Options) Options
 }
 
-// MessageFn processes the message.
-type MessageFn func(m Message)
+// ConsumeFn processes the consumer.
+type ConsumeFn func(c Consumer)
 
 // ServerOptions configs the consumer server.
 type ServerOptions interface {
-	// MessageFn returns the MessageFn.
-	MessageFn() MessageFn
+	// ConsumeFn returns the ConsumeFn.
+	ConsumeFn() ConsumeFn
 
-	// SetMessageFn sets the MessageFn.
-	SetMessageFn(value MessageFn) ServerOptions
+	// SetConsumeFn sets the ConsumeFn.
+	SetConsumeFn(value ConsumeFn) ServerOptions
 
 	// RetryOptions returns the options for connection retrier.
 	ServerOptions() server.Options

--- a/consumer/types.go
+++ b/consumer/types.go
@@ -24,7 +24,9 @@ import (
 	"net"
 
 	"github.com/m3db/m3msg/protocol/proto"
+	"github.com/m3db/m3x/instrument"
 	"github.com/m3db/m3x/pool"
+	"github.com/m3db/m3x/server"
 )
 
 // Message carries the data that needs to be processed.
@@ -34,6 +36,15 @@ type Message interface {
 
 	// Ack acks the message.
 	Ack()
+}
+
+// Consumer receives messages from a connection.
+type Consumer interface {
+	// Message waits for and returns the next message received.
+	Message() (Message, error)
+
+	// Close closes the consumer.
+	Close()
 }
 
 // Listener is a consumer listener based on a network address.
@@ -47,15 +58,6 @@ type Listener interface {
 
 	// Addr returns the listener's network address.
 	Addr() net.Addr
-}
-
-// Consumer receives messages from a connection.
-type Consumer interface {
-	// Message waits for and returns the next message received.
-	Message() (Message, error)
-
-	// Close closes the consumer.
-	Close()
 }
 
 // Options configs the consumer listener.
@@ -89,4 +91,34 @@ type Options interface {
 
 	// SetConnectionWriteBufferSize sets the buffer size.
 	SetConnectionReadBufferSize(value int) Options
+
+	// InstrumentOptions returns the instrument options.
+	InstrumentOptions() instrument.Options
+
+	// SetInstrumentOptions sets the instrument options.
+	SetInstrumentOptions(value instrument.Options) Options
+}
+
+// MessageFn processes the message.
+type MessageFn func(m Message)
+
+// ServerOptions configs the consumer server.
+type ServerOptions interface {
+	// MessageFn returns the MessageFn.
+	MessageFn() MessageFn
+
+	// SetMessageFn sets the MessageFn.
+	SetMessageFn(value MessageFn) ServerOptions
+
+	// RetryOptions returns the options for connection retrier.
+	ServerOptions() server.Options
+
+	// SetRetryOptions sets the options for connection retrier.
+	SetServerOptions(value server.Options) ServerOptions
+
+	// InstrumentOptions returns the instrument options.
+	ConsumerOptions() Options
+
+	// SetInstrumentOptions sets the instrument options.
+	SetConsumerOptions(value Options) ServerOptions
 }

--- a/producer/buffer/buffer.go
+++ b/producer/buffer/buffer.go
@@ -29,8 +29,8 @@ import (
 	"github.com/m3db/m3msg/producer"
 	"github.com/m3db/m3msg/producer/msg"
 
-	"github.com/uber-go/atomic"
 	"github.com/uber-go/tally"
+	"go.uber.org/atomic"
 )
 
 var (

--- a/producer/writer/options.go
+++ b/producer/writer/options.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	defaultDialTimeout               = 10 * time.Second
-	defaultKeepAlivePeriod           = 30 * time.Second
+	defaultKeepAlivePeriod           = time.Minute
 	defaultMessageQueueScanInterval  = 5 * time.Second
 	defaultPlacementWatchInitTimeout = 5 * time.Second
 	defaultTopicWatchInitTimeout     = 5 * time.Second


### PR DESCRIPTION
Originally I was planning to add a `MessageFn` like Kafka's interface, so users just need to pass in a lambda for processing messages, but in order to work with msgpack, it's better for us to reuse the iterator for the whole lifecycle of the consumer/connection so I changed the interface to take a `ConsumeFn`, maybe I can change the interface to use `MessageFn` once we migrated everything from msgpack to protobuf.

@xichen2020 