### PR TITLE
Improve fairness in consumer selection

### DIFF
--- a/producer/writer/consumer_writer.go
+++ b/producer/writer/consumer_writer.go
@@ -50,6 +50,9 @@ var (
 )
 
 type consumerWriter interface {
+	// Address returns the consumer address.
+	Address() string
+
 	// Write writes the marshaler, it should be thread safe.
 	Write(m proto.Marshaler) error
 
@@ -154,6 +157,10 @@ func newConsumerWriter(
 		w.notifyReset()
 	}
 	return w
+}
+
+func (w *consumerWriterImpl) Address() string {
+	return w.addr
 }
 
 // Write should fail fast so that the write could be tried on other

--- a/producer/writer/shard_writer.go
+++ b/producer/writer/shard_writer.go
@@ -89,7 +89,7 @@ func (w *sharedShardWriter) UpdateInstances(
 			continue
 		}
 		// Add the consumer writer to the message writer.
-		w.mw.AddConsumerWriter(id, cws[id])
+		w.mw.AddConsumerWriter(cws[id])
 	}
 	for id := range toBeDeleted {
 		w.mw.RemoveConsumerWriter(id)
@@ -182,7 +182,7 @@ func (w *replicatedShardWriter) UpdateInstances(
 		// messages buffered in the existing message writer can be tried on
 		// the new consumer writer.
 		if instance, cw, ok := anyKeyValueInMap(toBeAdded); ok {
-			mw.AddConsumerWriter(instance.Endpoint(), cw)
+			mw.AddConsumerWriter(cw)
 			mw.RemoveConsumerWriter(id)
 			w.updateCutoverCutoffNanos(mw, instance)
 			newMessageWriters[instance.Endpoint()] = mw
@@ -198,7 +198,7 @@ func (w *replicatedShardWriter) UpdateInstances(
 		replicatedShardID := uint64(w.replicaID*w.numberOfShards + w.shard)
 		w.replicaID++
 		mw := newMessageWriter(replicatedShardID, w.mPool, w.opts)
-		mw.AddConsumerWriter(instance.Endpoint(), cw)
+		mw.AddConsumerWriter(cw)
 		w.updateCutoverCutoffNanos(mw, instance)
 		mw.Init()
 		w.ackRouter.Register(replicatedShardID, mw)


### PR DESCRIPTION
The previous implementation was leveraging the randomness in map iteration for consumer selection, but benchmark shows that the map iteration is not providing enough fairness in choosing the first item,  for example, there is a >50% chance for 2 out of 10 consumers to be chosen as the first item in the iteration, this puts way more load on them than the other available consumers.

@xichen2020 