### PR TITLE
Message writer perf improvements

### DIFF
--- a/producer/config/writer.go
+++ b/producer/config/writer.go
@@ -75,7 +75,6 @@ type WriterConfiguration struct {
 	TopicWatchInitTimeout     *time.Duration                    `yaml:"topicWatchInitTimeout"`
 	PlacementServiceOverride  services.OverrideConfiguration    `yaml:"placementServiceOverride"`
 	PlacementWatchInitTimeout *time.Duration                    `yaml:"placementWatchInitTimeout"`
-	EnableMessagePooling      *bool                             `yaml:"enableMessagePooling"`
 	MessagePool               *pool.ObjectPoolConfiguration     `yaml:"messagePool"`
 	MessageRetry              *retry.Configuration              `yaml:"messageRetry"`
 	MessageQueueScanInterval  *time.Duration                    `yaml:"messageQueueScanInterval"`
@@ -116,9 +115,6 @@ func (c *WriterConfiguration) NewOptions(
 	opts = opts.SetServiceDiscovery(sd)
 	if c.PlacementWatchInitTimeout != nil {
 		opts = opts.SetPlacementWatchInitTimeout(*c.PlacementWatchInitTimeout)
-	}
-	if c.EnableMessagePooling != nil {
-		opts = opts.SetEnableMessagePooling(*c.EnableMessagePooling)
 	}
 	if c.MessagePool != nil {
 		opts = opts.SetMessagePoolOptions(c.MessagePool.NewObjectPoolOptions(iOpts))

--- a/producer/config/writer.go
+++ b/producer/config/writer.go
@@ -75,6 +75,7 @@ type WriterConfiguration struct {
 	TopicWatchInitTimeout     *time.Duration                    `yaml:"topicWatchInitTimeout"`
 	PlacementServiceOverride  services.OverrideConfiguration    `yaml:"placementServiceOverride"`
 	PlacementWatchInitTimeout *time.Duration                    `yaml:"placementWatchInitTimeout"`
+	EnableMessagePooling      *bool                             `yaml:"enableMessagePooling"`
 	MessagePool               *pool.ObjectPoolConfiguration     `yaml:"messagePool"`
 	MessageRetry              *retry.Configuration              `yaml:"messageRetry"`
 	MessageQueueScanInterval  *time.Duration                    `yaml:"messageQueueScanInterval"`
@@ -115,6 +116,9 @@ func (c *WriterConfiguration) NewOptions(
 	opts = opts.SetServiceDiscovery(sd)
 	if c.PlacementWatchInitTimeout != nil {
 		opts = opts.SetPlacementWatchInitTimeout(*c.PlacementWatchInitTimeout)
+	}
+	if c.EnableMessagePooling != nil {
+		opts = opts.SetEnableMessagePooling(*c.EnableMessagePooling)
 	}
 	if c.MessagePool != nil {
 		opts = opts.SetMessagePoolOptions(c.MessagePool.NewObjectPoolOptions(iOpts))

--- a/producer/writer/consumer_service_writer.go
+++ b/producer/writer/consumer_service_writer.go
@@ -120,7 +120,6 @@ type consumerServiceWriterImpl struct {
 func newConsumerServiceWriter(
 	cs topic.ConsumerService,
 	numShards uint32,
-	mPool messagePool,
 	opts Options,
 ) (consumerServiceWriter, error) {
 	ps, err := opts.ServiceDiscovery().PlacementService(cs.ServiceID(), nil)
@@ -132,6 +131,8 @@ func newConsumerServiceWriter(
 		return nil, errUnknownConsumptionType
 	}
 	router := newAckRouter(int(numShards))
+	mPool := newMessagePool(opts.MessagePoolOptions())
+	mPool.Init()
 	w := &consumerServiceWriterImpl{
 		cs:              cs,
 		ps:              ps,

--- a/producer/writer/consumer_service_writer.go
+++ b/producer/writer/consumer_service_writer.go
@@ -160,7 +160,7 @@ func initShardWriters(
 		m     = newMessageWriterMetrics(opts.InstrumentOptions().MetricsScope())
 		mPool messagePool
 	)
-	if opts.EnableMessagePooling() {
+	if opts.MessagePoolOptions() != nil {
 		mPool = newMessagePool(opts.MessagePoolOptions())
 		mPool.Init()
 	}

--- a/producer/writer/consumer_service_writer_test.go
+++ b/producer/writer/consumer_service_writer_test.go
@@ -59,7 +59,7 @@ func TestConsumerServiceWriterWithSharedConsumerWithNonShardedPlacement(t *testi
 	sd.EXPECT().PlacementService(sid, gomock.Any()).Return(ps, nil)
 
 	opts := testOptions().SetServiceDiscovery(sd)
-	w, err := newConsumerServiceWriter(cs, 2, testMessagePool(opts), opts)
+	w, err := newConsumerServiceWriter(cs, 2, opts)
 	require.NoError(t, err)
 
 	csw := w.(*consumerServiceWriterImpl)
@@ -180,7 +180,7 @@ func TestConsumerServiceWriterWithSharedConsumerWithShardedPlacement(t *testing.
 	sd.EXPECT().PlacementService(sid, gomock.Any()).Return(ps, nil)
 
 	opts := testOptions().SetServiceDiscovery(sd)
-	w, err := newConsumerServiceWriter(cs, 3, testMessagePool(opts), opts)
+	w, err := newConsumerServiceWriter(cs, 3, opts)
 	require.NoError(t, err)
 
 	csw := w.(*consumerServiceWriterImpl)
@@ -350,7 +350,7 @@ func TestConsumerServiceWriterWithReplicatedConsumerWithShardedPlacement(t *test
 	require.NoError(t, ps.Set(p1))
 
 	opts := testOptions().SetServiceDiscovery(sd)
-	w, err := newConsumerServiceWriter(cs, 2, testMessagePool(opts), opts)
+	w, err := newConsumerServiceWriter(cs, 2, opts)
 	csw := w.(*consumerServiceWriterImpl)
 	require.NoError(t, err)
 	require.NotNil(t, csw)
@@ -490,7 +490,7 @@ func TestConsumerServiceWriterFilter(t *testing.T) {
 	sd.EXPECT().PlacementService(sid, gomock.Any()).Return(ps, nil)
 
 	opts := testOptions().SetServiceDiscovery(sd)
-	csw, err := newConsumerServiceWriter(cs, 3, testMessagePool(opts), opts)
+	csw, err := newConsumerServiceWriter(cs, 3, opts)
 	require.NoError(t, err)
 
 	sw0 := NewMockshardWriter(ctrl)
@@ -535,7 +535,7 @@ func TestConsumerServiceWriterAllowInitValueErrorWithCreateWatchError(t *testing
 	sd.EXPECT().PlacementService(sid, gomock.Any()).Return(ps, nil)
 
 	opts := testOptions().SetServiceDiscovery(sd)
-	w, err := newConsumerServiceWriter(cs, 3, testMessagePool(opts), opts)
+	w, err := newConsumerServiceWriter(cs, 3, opts)
 	require.NoError(t, err)
 	defer w.Close()
 
@@ -556,7 +556,7 @@ func TestConsumerServiceWriterAllowInitValueErrorWithInitValueError(t *testing.T
 	sd.EXPECT().PlacementService(sid, gomock.Any()).Return(ps, nil)
 
 	opts := testOptions().SetServiceDiscovery(sd)
-	w, err := newConsumerServiceWriter(cs, 3, testMessagePool(opts), opts)
+	w, err := newConsumerServiceWriter(cs, 3, opts)
 	require.NoError(t, err)
 	defer w.Close()
 
@@ -579,7 +579,7 @@ func TestConsumerServiceWriterInitWithCreateWatchError(t *testing.T) {
 	sd.EXPECT().PlacementService(sid, gomock.Any()).Return(ps, nil)
 
 	opts := testOptions().SetServiceDiscovery(sd)
-	w, err := newConsumerServiceWriter(cs, 3, testMessagePool(opts), opts)
+	w, err := newConsumerServiceWriter(cs, 3, opts)
 	require.NoError(t, err)
 	defer w.Close()
 
@@ -603,7 +603,7 @@ func TestConsumerServiceWriterInitWithInitValueError(t *testing.T) {
 	sd.EXPECT().PlacementService(sid, gomock.Any()).Return(ps, nil)
 
 	opts := testOptions().SetServiceDiscovery(sd)
-	w, err := newConsumerServiceWriter(cs, 3, testMessagePool(opts), opts)
+	w, err := newConsumerServiceWriter(cs, 3, opts)
 	require.NoError(t, err)
 	defer w.Close()
 

--- a/producer/writer/message.go
+++ b/producer/writer/message.go
@@ -24,6 +24,7 @@ import (
 	"github.com/m3db/m3msg/generated/proto/msgpb"
 	"github.com/m3db/m3msg/producer"
 	"github.com/m3db/m3msg/protocol/proto"
+
 	"go.uber.org/atomic"
 )
 

--- a/producer/writer/message.go
+++ b/producer/writer/message.go
@@ -53,7 +53,8 @@ func (m *message) Set(meta metadata, rm producer.RefCountedMessage) {
 	m.ToProto(&m.pb)
 }
 
-func (m *message) Reset() {
+// Close resets the states of the message.
+func (m *message) Close() {
 	m.retryAtNanos = 0
 	m.retried = 0
 	m.isAcked.Store(false)

--- a/producer/writer/message.go
+++ b/producer/writer/message.go
@@ -46,11 +46,14 @@ func newMessage() *message {
 	}
 }
 
-// Reset resets the message.
-func (m *message) Reset(meta metadata, rm producer.RefCountedMessage) {
+// Set sets the message.
+func (m *message) Set(meta metadata, rm producer.RefCountedMessage) {
 	m.meta = meta
 	m.RefCountedMessage = rm
 	m.ToProto(&m.pb)
+}
+
+func (m *message) Reset() {
 	m.retryAtNanos = 0
 	m.retried = 0
 	m.isAcked.Store(false)

--- a/producer/writer/message.go
+++ b/producer/writer/message.go
@@ -34,7 +34,8 @@ type message struct {
 	meta         metadata
 	retryAtNanos int64
 	retried      int
-	// NB(cw) isAcked could be accessed concurrently.
+	// NB(cw) isAcked could be accessed concurrently by the background thread
+	// in message writer and acked by consumer service writers.
 	isAcked *atomic.Bool
 }
 

--- a/producer/writer/message_pool_test.go
+++ b/producer/writer/message_pool_test.go
@@ -46,7 +46,7 @@ func TestMessagePool(t *testing.T) {
 	m := p.Get()
 	require.Nil(t, m.pb.Value)
 	mm.EXPECT().Bytes().Return([]byte("foo"))
-	m.Reset(metadata{}, rm)
+	m.Set(metadata{}, rm)
 	m.SetRetryAtNanos(100)
 
 	pb, ok := m.Marshaler()
@@ -62,6 +62,6 @@ func TestMessagePool(t *testing.T) {
 	require.True(t, m.IsDroppedOrConsumed())
 
 	mm.EXPECT().Bytes().Return([]byte("foo"))
-	m.Reset(metadata{}, msg.NewRefCountedMessage(mm, nil))
+	m.Set(metadata{}, msg.NewRefCountedMessage(mm, nil))
 	require.False(t, m.IsDroppedOrConsumed())
 }

--- a/producer/writer/message_writer.go
+++ b/producer/writer/message_writer.go
@@ -335,7 +335,7 @@ func (w *messageWriterImpl) retryBatchWithLock(
 			// do not stay in memory forever.
 			w.Ack(m.Metadata())
 			w.queue.Remove(e)
-			m.Reset()
+			m.Close()
 			w.mPool.Put(m)
 			continue
 		}
@@ -346,7 +346,7 @@ func (w *messageWriterImpl) retryBatchWithLock(
 			// Try removing the ack in case the message was dropped rather than acked.
 			w.acks.remove(m.Metadata())
 			w.queue.Remove(e)
-			m.Reset()
+			m.Close()
 			w.mPool.Put(m)
 			continue
 		}

--- a/producer/writer/message_writer.go
+++ b/producer/writer/message_writer.go
@@ -174,7 +174,7 @@ func (w *messageWriterImpl) Write(rm producer.RefCountedMessage) {
 		shard: w.replicatedShardID,
 		id:    w.msgID,
 	}
-	msg.Reset(meta, rm)
+	msg.Set(meta, rm)
 	w.acks.add(meta, msg)
 	w.queue.PushBack(msg)
 	w.Unlock()
@@ -332,6 +332,7 @@ func (w *messageWriterImpl) retryBatchWithLock(
 			// do not stay in memory forever.
 			w.Ack(m.Metadata())
 			w.queue.Remove(e)
+			m.Reset()
 			w.mPool.Put(m)
 			continue
 		}
@@ -342,6 +343,7 @@ func (w *messageWriterImpl) retryBatchWithLock(
 			// Try removing the ack in case the message was dropped rather than acked.
 			w.acks.remove(m.Metadata())
 			w.queue.Remove(e)
+			m.Reset()
 			w.mPool.Put(m)
 			continue
 		}

--- a/producer/writer/message_writer.go
+++ b/producer/writer/message_writer.go
@@ -228,9 +228,9 @@ func (w *messageWriterImpl) write(
 	m.SetRetryAtNanos(w.nextRetryNanos(m.WriteTimes(), nowNanos))
 }
 
-func (w *messageWriterImpl) nextRetryNanos(writeTimes int64, nowNanos int64) int64 {
+func (w *messageWriterImpl) nextRetryNanos(writeTimes int, nowNanos int64) int64 {
 	backoff := retry.BackoffNanos(
-		int(writeTimes),
+		writeTimes,
 		w.retryOpts.Jitter(),
 		w.retryOpts.BackoffFactor(),
 		w.retryOpts.InitialBackoff(),

--- a/producer/writer/message_writer.go
+++ b/producer/writer/message_writer.go
@@ -80,7 +80,7 @@ type messageWriterMetrics struct {
 	writeAfterCutoff       tally.Counter
 	writeBeforeCutover     tally.Counter
 	retryBatchLatency      tally.Timer
-	retryLatency           tally.Timer
+	retryTotalLatency      tally.Timer
 }
 
 func newMessageWriterMetrics(scope tally.Scope) messageWriterMetrics {
@@ -100,7 +100,7 @@ func newMessageWriterMetrics(scope tally.Scope) messageWriterMetrics {
 			Tagged(map[string]string{"reason": "before-cutover"}).
 			Counter("invalid-write"),
 		retryBatchLatency: scope.Timer("retry-batch-latency"),
-		retryLatency:      scope.Timer("retry-latency"),
+		retryTotalLatency: scope.Timer("retry-total-latency"),
 	}
 }
 
@@ -300,7 +300,7 @@ func (w *messageWriterImpl) retryUnacknowledged() {
 		}
 		w.m.retryBatchLatency.Record(w.nowFn().Sub(now))
 	}
-	w.m.retryLatency.Record(w.nowFn().Sub(beforeRetry))
+	w.m.retryTotalLatency.Record(w.nowFn().Sub(beforeRetry))
 }
 
 // retryBatchWithLock iterates the message queue with a lock.

--- a/producer/writer/message_writer_test.go
+++ b/producer/writer/message_writer_test.go
@@ -146,12 +146,6 @@ func TestMessageWriterRetry(t *testing.T) {
 	w.AddConsumerWriter(newConsumerWriter("bad", a, opts, testConsumerWriterMetrics()))
 	require.Equal(t, 1, w.queue.Len())
 
-	cw := newConsumerWriter(addr, a, opts, testConsumerWriterMetrics())
-	cw.Init()
-	defer cw.Close()
-
-	w.AddConsumerWriter(cw)
-
 	for {
 		if !isEmptyWithLock(w.acks) {
 			break
@@ -162,6 +156,11 @@ func TestMessageWriterRetry(t *testing.T) {
 	_, ok := w.acks.m[metadata{shard: 200, id: 1}]
 	require.True(t, ok)
 
+	cw := newConsumerWriter(addr, a, opts, testConsumerWriterMetrics())
+	cw.Init()
+	defer cw.Close()
+
+	w.AddConsumerWriter(cw)
 	go func() {
 		testConsumeAndAckOnConnectionListener(t, lis, opts.EncodeDecoderOptions())
 	}()

--- a/producer/writer/message_writer_test.go
+++ b/producer/writer/message_writer_test.go
@@ -136,15 +136,6 @@ func TestMessageWriterRetry(t *testing.T) {
 	defer w.Close()
 
 	w.AddConsumerWriter(newConsumerWriter("bad", a, opts, testConsumerWriterMetrics()))
-	for {
-		w.RLock()
-		retried := msg.WriteTimes()
-		w.RUnlock()
-		if retried != 0 {
-			break
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
 	require.Equal(t, 1, w.queue.Len())
 
 	cw := newConsumerWriter(addr, a, opts, testConsumerWriterMetrics())

--- a/producer/writer/message_writer_test.go
+++ b/producer/writer/message_writer_test.go
@@ -220,7 +220,10 @@ func TestMessageWriterCleanupAckedMessage(t *testing.T) {
 
 	w.Write(rm)
 	acks := w.(*messageWriterImpl).acks
-	var meta metadata
+	meta := metadata{
+		id:    1,
+		shard: 2,
+	}
 	acks.Lock()
 	for m := range acks.m {
 		meta = m
@@ -251,7 +254,7 @@ func TestMessageWriterCleanupAckedMessage(t *testing.T) {
 
 	// A get will NOT allocate a new message because the old one has been returned to pool.
 	m = w.(*messageWriterImpl).mPool.Get()
-	require.True(t, m.IsDroppedOrAcked())
+	require.Equal(t, meta, m.Metadata())
 }
 
 func TestMessageWriterCutoverCutoff(t *testing.T) {

--- a/producer/writer/message_writer_test.go
+++ b/producer/writer/message_writer_test.go
@@ -293,7 +293,7 @@ func TestMessageWriterRetryWithPooling(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 	}
 
-	_, ok := w.acks.m[metadata{shard: 200, id: 1}]
+	m1, ok := w.acks.m[metadata{shard: 200, id: 1}]
 	require.True(t, ok)
 
 	cw := newConsumerWriter(addr, a, opts, testConsumerWriterMetrics())
@@ -317,6 +317,7 @@ func TestMessageWriterRetryWithPooling(t *testing.T) {
 
 	// A get will NOT allocate a new message because the old one has been returned to pool.
 	m := w.mPool.Get()
+	require.Equal(t, m1, m)
 	require.True(t, m.IsDroppedOrConsumed())
 }
 

--- a/producer/writer/options.go
+++ b/producer/writer/options.go
@@ -216,12 +216,6 @@ type Options interface {
 	// SetPlacementWatchInitTimeout sets the timeout for placement watch initialization.
 	SetPlacementWatchInitTimeout(value time.Duration) Options
 
-	// EnableMessagePooling returns whether message pooling is enabled.
-	EnableMessagePooling() bool
-
-	// SetEnableMessagePooling sets whether message pooling is enabled.
-	SetEnableMessagePooling(value bool) Options
-
 	// MessagePoolOptions returns the options of pool for messages.
 	MessagePoolOptions() pool.ObjectPoolOptions
 
@@ -289,7 +283,6 @@ type writerOptions struct {
 	topicWatchInitTimeout     time.Duration
 	services                  services.Services
 	placementWatchInitTimeout time.Duration
-	enableMessagePooling      bool
 	messagePoolOptions        pool.ObjectPoolOptions
 	messageRetryOpts          retry.Options
 	messageQueueScanInterval  time.Duration
@@ -307,8 +300,6 @@ func NewOptions() Options {
 	return &writerOptions{
 		topicWatchInitTimeout:     defaultTopicWatchInitTimeout,
 		placementWatchInitTimeout: defaultPlacementWatchInitTimeout,
-		enableMessagePooling:      false,
-		messagePoolOptions:        pool.NewObjectPoolOptions(),
 		messageRetryOpts:          retry.NewOptions(),
 		messageQueueScanInterval:  defaultMessageQueueScanInterval,
 		messageRetryBatchSize:     defaultMessageRetryBatchSize,
@@ -368,16 +359,6 @@ func (opts *writerOptions) PlacementWatchInitTimeout() time.Duration {
 func (opts *writerOptions) SetPlacementWatchInitTimeout(value time.Duration) Options {
 	o := *opts
 	o.placementWatchInitTimeout = value
-	return &o
-}
-
-func (opts *writerOptions) EnableMessagePooling() bool {
-	return opts.enableMessagePooling
-}
-
-func (opts *writerOptions) SetEnableMessagePooling(value bool) Options {
-	o := *opts
-	o.enableMessagePooling = value
 	return &o
 }
 

--- a/producer/writer/options.go
+++ b/producer/writer/options.go
@@ -216,6 +216,12 @@ type Options interface {
 	// SetPlacementWatchInitTimeout sets the timeout for placement watch initialization.
 	SetPlacementWatchInitTimeout(value time.Duration) Options
 
+	// EnableMessagePooling returns whether message pooling is enabled.
+	EnableMessagePooling() bool
+
+	// SetEnableMessagePooling sets whether message pooling is enabled.
+	SetEnableMessagePooling(value bool) Options
+
 	// MessagePoolOptions returns the options of pool for messages.
 	MessagePoolOptions() pool.ObjectPoolOptions
 
@@ -283,6 +289,7 @@ type writerOptions struct {
 	topicWatchInitTimeout     time.Duration
 	services                  services.Services
 	placementWatchInitTimeout time.Duration
+	enableMessagePooling      bool
 	messagePoolOptions        pool.ObjectPoolOptions
 	messageRetryOpts          retry.Options
 	messageQueueScanInterval  time.Duration
@@ -300,6 +307,7 @@ func NewOptions() Options {
 	return &writerOptions{
 		topicWatchInitTimeout:     defaultTopicWatchInitTimeout,
 		placementWatchInitTimeout: defaultPlacementWatchInitTimeout,
+		enableMessagePooling:      false,
 		messagePoolOptions:        pool.NewObjectPoolOptions(),
 		messageRetryOpts:          retry.NewOptions(),
 		messageQueueScanInterval:  defaultMessageQueueScanInterval,
@@ -360,6 +368,16 @@ func (opts *writerOptions) PlacementWatchInitTimeout() time.Duration {
 func (opts *writerOptions) SetPlacementWatchInitTimeout(value time.Duration) Options {
 	o := *opts
 	o.placementWatchInitTimeout = value
+	return &o
+}
+
+func (opts *writerOptions) EnableMessagePooling() bool {
+	return opts.enableMessagePooling
+}
+
+func (opts *writerOptions) SetEnableMessagePooling(value bool) Options {
+	o := *opts
+	o.enableMessagePooling = value
 	return &o
 }
 

--- a/producer/writer/options_test.go
+++ b/producer/writer/options_test.go
@@ -41,6 +41,9 @@ func TestOptions(t *testing.T) {
 	require.Equal(t, defaultPlacementWatchInitTimeout, opts.PlacementWatchInitTimeout())
 	require.Equal(t, time.Second, opts.SetPlacementWatchInitTimeout(time.Second).PlacementWatchInitTimeout())
 
+	require.False(t, opts.EnableMessagePooling())
+	require.True(t, opts.SetEnableMessagePooling(true).EnableMessagePooling())
+
 	require.Equal(t, defaultMessageQueueScanInterval, opts.MessageQueueScanInterval())
 	require.Equal(t, time.Second, opts.SetMessageQueueScanInterval(time.Second).MessageQueueScanInterval())
 

--- a/producer/writer/options_test.go
+++ b/producer/writer/options_test.go
@@ -41,11 +41,10 @@ func TestOptions(t *testing.T) {
 	require.Equal(t, defaultPlacementWatchInitTimeout, opts.PlacementWatchInitTimeout())
 	require.Equal(t, time.Second, opts.SetPlacementWatchInitTimeout(time.Second).PlacementWatchInitTimeout())
 
-	require.False(t, opts.EnableMessagePooling())
-	require.True(t, opts.SetEnableMessagePooling(true).EnableMessagePooling())
-
 	require.Equal(t, defaultMessageQueueScanInterval, opts.MessageQueueScanInterval())
 	require.Equal(t, time.Second, opts.SetMessageQueueScanInterval(time.Second).MessageQueueScanInterval())
+
+	require.Nil(t, opts.MessagePoolOptions())
 
 	require.Equal(t, defaultInitialAckMapSize, opts.InitialAckMapSize())
 	require.Equal(t, 123, opts.SetInitialAckMapSize(123).InitialAckMapSize())


### PR DESCRIPTION
- Instead have all message writers across all consumer services to share the same global message pool, this pr creates a message pool per consumer service, which reduces lock contention on the pool.

- remove unnecessary atomic usage in message.go

- move the following expensive operations away from Write() to the background retry thread.
  - reset the atomic.Bool in message
  - add the message to the ack map