### PR TITLE
Performance improvements

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -572,7 +572,7 @@ func TestAddConsumerService(t *testing.T) {
 		s.ScheduleOperations(
 			20,
 			func() {
-				s.AddConsumerService(t, consumerServiceConfig{ct: topic.Shared, isSharded: false, instances: 1, replicas: 1})
+				s.AddConsumerService(t, consumerServiceConfig{ct: topic.Shared, isSharded: false, instances: 1, replicas: 1, lateJoin: true})
 			},
 		)
 		s.Run(t, ctrl)

--- a/integration/setup.go
+++ b/integration/setup.go
@@ -541,7 +541,7 @@ writer:
   messageRetry:
     initialBackoff: 20ms
     maxBackoff: 50ms
-	messageQueueScanInterval: 10ms
+  messageQueueScanInterval: 10ms
   closeCheckInterval: 200ms
   ackErrorRetry: 
     initialBackoff: 20ms

--- a/integration/setup.go
+++ b/integration/setup.go
@@ -61,6 +61,7 @@ type consumerServiceConfig struct {
 	instances int
 	replicas  int
 	isSharded bool
+	lateJoin  bool
 }
 
 type op struct {
@@ -71,7 +72,6 @@ type op struct {
 type setup struct {
 	ts               topic.Service
 	sd               *services.MockServices
-	configs          []consumerServiceConfig
 	producers        []producer.Producer
 	consumerServices []*testConsumerService
 	totalConsumed    *atomic.Int64
@@ -124,7 +124,6 @@ func newTestSetup(
 	return &setup{
 		ts:               ts,
 		sd:               sd,
-		configs:          configs,
 		producers:        producers,
 		consumerServices: testConsumerServices,
 		totalConsumed:    totalConsumed,
@@ -150,6 +149,7 @@ func newTestConsumerService(
 		sid:              sid,
 		placementService: ps,
 		consumerService:  consumerService,
+		config:           config,
 	}
 	var (
 		instances []placement.Instance
@@ -218,12 +218,15 @@ func (s *setup) Run(
 	s.CloseConsumers()
 
 	expectedConsumeReplica := 0
-	for _, csc := range s.configs {
-		if csc.ct == topic.Shared {
+	for _, cs := range s.consumerServices {
+		if cs.config.lateJoin {
+			continue
+		}
+		if cs.config.ct == topic.Shared {
 			expectedConsumeReplica++
 			continue
 		}
-		expectedConsumeReplica += csc.replicas
+		expectedConsumeReplica += cs.config.replicas
 	}
 	expectedConsumed := expectedConsumeReplica * numWritesPerProducer * len(s.producers)
 	require.True(t, int(s.totalConsumed.Load()) >= expectedConsumed, fmt.Sprintf("expect %d, consumed %d", expectedConsumed, s.totalConsumed.Load()))
@@ -242,8 +245,9 @@ func (s *setup) CloseProducers(dur time.Duration) {
 
 	go func() {
 		for _, p := range s.producers {
+			log.SimpleLogger.Debug("closing producer")
 			p.Close(producer.WaitForConsumption)
-			log.SimpleLogger.Debug("producer closed")
+			log.SimpleLogger.Debug("closed producer")
 		}
 		close(doneCh)
 	}()
@@ -371,10 +375,8 @@ func (s *setup) RemoveConsumerService(t *testing.T, idx int) {
 	topic = topic.SetConsumerServices(append(css[:idx], css[idx+1:]...))
 	s.ts.CheckAndSet(topic, topic.Version())
 	tcss := s.consumerServices
-	tcs := tcss[idx]
+	tcss[idx].Close()
 	s.consumerServices = append(tcss[:idx], tcss[idx+1:]...)
-	tcs.Close()
-	s.configs = append(s.configs[:idx], s.configs[idx+1:]...)
 }
 
 func (s *setup) AddConsumerService(t *testing.T, config consumerServiceConfig) {
@@ -394,6 +396,7 @@ type testConsumerService struct {
 	placementService placement.Service
 	consumerService  topic.ConsumerService
 	testConsumers    []*testConsumer
+	config           consumerServiceConfig
 }
 
 func (cs *testConsumerService) markConsumed(b []byte) {
@@ -526,6 +529,9 @@ func testProducer(
 	cs client.Client,
 ) producer.Producer {
 	str := `
+buffer:
+  cleanupInterval: 200ms
+  closeCheckInterval: 200ms
 writer:
   topicName: topicName
   topicWatchInitTimeout: 100ms
@@ -535,7 +541,7 @@ writer:
   messageRetry:
     initialBackoff: 20ms
     maxBackoff: 50ms
-  messageQueueScanInterval: 10ms
+	messageQueueScanInterval: 10ms
   closeCheckInterval: 200ms
   ackErrorRetry: 
     initialBackoff: 20ms

--- a/producer/buffer/buffer.go
+++ b/producer/buffer/buffer.go
@@ -50,8 +50,8 @@ type bufferMetrics struct {
 
 func newBufferMetrics(scope tally.Scope) bufferMetrics {
 	return bufferMetrics{
-		messageDropped:  scope.Counter("message-dropped"),
-		byteDropped:     scope.Counter("byte-dropped"),
+		messageDropped:  scope.Counter("buffer-message-dropped"),
+		byteDropped:     scope.Counter("buffer-byte-dropped"),
 		messageTooLarge: scope.Counter("message-too-large"),
 		messageBuffered: scope.Gauge("message-buffered"),
 		byteBuffered:    scope.Gauge("byte-buffered"),

--- a/producer/buffer/options.go
+++ b/producer/buffer/options.go
@@ -29,7 +29,7 @@ import (
 var (
 	defaultMaxBufferSize      = 100 * 1024 * 1024 // 100MB.
 	defaultMaxMessageSize     = 1 * 1024 * 1024   // 1MB.
-	defaultCleanupInterval    = time.Second
+	defaultCleanupInterval    = 5 * time.Second
 	defaultCloseCheckInterval = time.Second
 )
 

--- a/producer/writer/consumer_service_writer.go
+++ b/producer/writer/consumer_service_writer.go
@@ -285,15 +285,15 @@ func (w *consumerServiceWriterImpl) diffPlacementWithLock(newPlacement placement
 
 func (w *consumerServiceWriterImpl) Close() {
 	w.Lock()
-	defer w.Unlock()
-
 	if w.closed {
+		w.Unlock()
 		return
 	}
-	w.logger.Infof("closing consumer service writer %s", w.cs.String())
 	w.closed = true
-	close(w.doneCh)
+	w.Unlock()
 
+	w.logger.Infof("closing consumer service writer %s", w.cs.String())
+	close(w.doneCh)
 	// Blocks until all messages consuemd.
 	var shardWriterWG sync.WaitGroup
 	for _, sw := range w.shardWriters {

--- a/producer/writer/consumer_service_writer.go
+++ b/producer/writer/consumer_service_writer.go
@@ -95,7 +95,7 @@ func newConsumerServiceWriterMetrics(scope tally.Scope) consumerServiceWriterMet
 }
 
 type consumerServiceWriterImpl struct {
-	sync.RWMutex
+	sync.Mutex
 
 	cs           topic.ConsumerService
 	ps           placement.Service
@@ -156,7 +156,7 @@ func initShardWriters(
 ) []shardWriter {
 	var (
 		sws   = make([]shardWriter, numberOfShards)
-		m     = newMessageWriterMetrics(opts.InstrumentOptions().MetricsScope())
+		m     = newMessageWriterMetrics(opts.InstrumentOptions())
 		mPool messagePool
 	)
 	if opts.MessagePoolOptions() != nil {

--- a/producer/writer/consumer_service_writer.go
+++ b/producer/writer/consumer_service_writer.go
@@ -155,8 +155,11 @@ func initShardWriters(
 	opts Options,
 ) []shardWriter {
 	var (
-		sws   = make([]shardWriter, numberOfShards)
-		m     = newMessageWriterMetrics(opts.InstrumentOptions())
+		sws = make([]shardWriter, numberOfShards)
+		m   = newMessageWriterMetrics(
+			opts.InstrumentOptions().MetricsScope(),
+			opts.InstrumentOptions().MetricsSamplingRate(),
+		)
 		mPool messagePool
 	)
 	if opts.MessagePoolOptions() != nil {

--- a/producer/writer/consumer_writer_test.go
+++ b/producer/writer/consumer_writer_test.go
@@ -100,21 +100,21 @@ func TestConsumerWriterSignalResetConnection(t *testing.T) {
 
 	w.notifyReset()
 	require.Equal(t, 1, len(w.resetCh))
-	require.True(t, w.resetWaitNanos() > 0)
+	require.True(t, w.resetTooSoon())
 
 	now := time.Now()
 	w.nowFn = func() time.Time { return now.Add(1 * time.Hour) }
 	require.Equal(t, 1, len(w.resetCh))
-	require.False(t, w.resetWaitNanos() > 0)
+	require.False(t, w.resetTooSoon())
 	require.NoError(t, w.resetWithConnectFn(w.connectFn))
 	require.Equal(t, 1, called)
 	require.Equal(t, 1, len(w.resetCh))
 
 	// Reset won't do anything as it is too soon since last reset.
-	require.True(t, w.resetWaitNanos() > 0)
+	require.True(t, w.resetTooSoon())
 
 	w.nowFn = func() time.Time { return now.Add(2 * time.Hour) }
-	require.False(t, w.resetWaitNanos() > 0)
+	require.False(t, w.resetTooSoon())
 	require.NoError(t, w.resetWithConnectFn(w.connectFn))
 	require.Equal(t, 2, called)
 }

--- a/producer/writer/consumer_writer_test.go
+++ b/producer/writer/consumer_writer_test.go
@@ -100,21 +100,21 @@ func TestConsumerWriterSignalResetConnection(t *testing.T) {
 
 	w.notifyReset()
 	require.Equal(t, 1, len(w.resetCh))
-	require.True(t, w.resetTooSoon())
+	require.True(t, w.resetWaitNanos() > 0)
 
 	now := time.Now()
 	w.nowFn = func() time.Time { return now.Add(1 * time.Hour) }
 	require.Equal(t, 1, len(w.resetCh))
-	require.False(t, w.resetTooSoon())
+	require.False(t, w.resetWaitNanos() > 0)
 	require.NoError(t, w.resetWithConnectFn(w.connectFn))
 	require.Equal(t, 1, called)
 	require.Equal(t, 1, len(w.resetCh))
 
 	// Reset won't do anything as it is too soon since last reset.
-	require.True(t, w.resetTooSoon())
+	require.True(t, w.resetWaitNanos() > 0)
 
 	w.nowFn = func() time.Time { return now.Add(2 * time.Hour) }
-	require.False(t, w.resetTooSoon())
+	require.False(t, w.resetWaitNanos() > 0)
 	require.NoError(t, w.resetWithConnectFn(w.connectFn))
 	require.Equal(t, 2, called)
 }

--- a/producer/writer/message.go
+++ b/producer/writer/message.go
@@ -82,8 +82,8 @@ func (m *message) IncWriteTimes() {
 	m.retried++
 }
 
-// Acked returns true if the message has been acked.
-func (m *message) Acked() bool {
+// IsAcked returns true if the message has been acked.
+func (m *message) IsAcked() bool {
 	return m.isAcked.Load()
 }
 

--- a/producer/writer/message.go
+++ b/producer/writer/message.go
@@ -82,9 +82,9 @@ func (m *message) IncWriteTimes() {
 	m.retried++
 }
 
-// IsDroppedOrAcked returns true if the message has been dropped or acked.
-func (m *message) IsDroppedOrAcked() bool {
-	return m.isAcked.Load() || m.RefCountedMessage.IsDroppedOrConsumed()
+// Acked returns true if the message has been acked.
+func (m *message) Acked() bool {
+	return m.isAcked.Load()
 }
 
 // Ack acknowledges the message. Duplicated acks on the same message might cause panic.

--- a/producer/writer/message_writer.go
+++ b/producer/writer/message_writer.go
@@ -93,8 +93,10 @@ type messageWriterMetrics struct {
 	retryTotalLatency      tally.Timer
 }
 
-func newMessageWriterMetrics(iOpts instrument.Options) messageWriterMetrics {
-	scope := iOpts.MetricsScope()
+func newMessageWriterMetrics(
+	scope tally.Scope,
+	samplingRate float64,
+) messageWriterMetrics {
 	return messageWriterMetrics{
 		writeSuccess:          scope.Counter("write-success"),
 		oneConsumerWriteError: scope.Counter("write-error-one-consumer"),
@@ -113,8 +115,8 @@ func newMessageWriterMetrics(iOpts instrument.Options) messageWriterMetrics {
 		messageAcked:      scope.Counter("message-acked"),
 		messageClosed:     scope.Counter("message-closed"),
 		messageDropped:    scope.Counter("message-dropped"),
-		retryBatchLatency: instrument.MustCreateSampledTimer(scope.Timer("retry-batch-latency"), iOpts.MetricsSamplingRate()),
-		retryTotalLatency: instrument.MustCreateSampledTimer(scope.Timer("retry-total-latency"), iOpts.MetricsSamplingRate()),
+		retryBatchLatency: instrument.MustCreateSampledTimer(scope.Timer("retry-batch-latency"), samplingRate),
+		retryTotalLatency: instrument.MustCreateSampledTimer(scope.Timer("retry-total-latency"), samplingRate),
 	}
 }
 

--- a/producer/writer/message_writer.go
+++ b/producer/writer/message_writer.go
@@ -22,6 +22,7 @@ package writer
 
 import (
 	"container/list"
+	"errors"
 	"math/rand"
 	"sync"
 	"time"
@@ -31,6 +32,11 @@ import (
 	"github.com/m3db/m3x/retry"
 
 	"github.com/uber-go/tally"
+)
+
+var (
+	errFailAllConsumers = errors.New("could not write to any consumer")
+	errNoWriters        = errors.New("no writers")
 )
 
 type messageWriter interface {
@@ -79,6 +85,9 @@ type messageWriterMetrics struct {
 	noWritersError         tally.Counter
 	writeAfterCutoff       tally.Counter
 	writeBeforeCutover     tally.Counter
+	messageAcked           tally.Counter
+	messageClosed          tally.Counter
+	messageDropped         tally.Counter
 	retryBatchLatency      tally.Timer
 	retryTotalLatency      tally.Timer
 }
@@ -99,6 +108,9 @@ func newMessageWriterMetrics(scope tally.Scope) messageWriterMetrics {
 		writeBeforeCutover: scope.
 			Tagged(map[string]string{"reason": "before-cutover"}).
 			Counter("invalid-write"),
+		messageAcked:      scope.Counter("message-acked"),
+		messageClosed:     scope.Counter("message-closed"),
+		messageDropped:    scope.Counter("message-dropped"),
 		retryBatchLatency: scope.Timer("retry-batch-latency"),
 		retryTotalLatency: scope.Timer("retry-total-latency"),
 	}
@@ -174,6 +186,7 @@ func (w *messageWriterImpl) Write(rm producer.RefCountedMessage) {
 		id:    w.msgID,
 	}
 	msg.Set(meta, rm)
+	w.acks.add(meta, msg)
 	w.queue.PushBack(msg)
 	w.Unlock()
 }
@@ -193,13 +206,12 @@ func (w *messageWriterImpl) isValidWriteWithLock(nowNanos int64) bool {
 func (w *messageWriterImpl) write(
 	consumerWriters []consumerWriter,
 	m *message,
-) {
-	m.IncWriteTimes()
+) error {
 	m.IncReads()
 	msg, isValid := m.Marshaler()
 	if !isValid {
 		m.DecReads()
-		return
+		return nil
 	}
 	var (
 		written  = false
@@ -218,13 +230,12 @@ func (w *messageWriterImpl) write(
 		break
 	}
 	m.DecReads()
-
-	if !written {
-		// Could not be written to any consumer, will retry later.
-		w.m.allConsumersWriteError.Inc(1)
-		return
+	if written {
+		return nil
 	}
-	m.SetRetryAtNanos(w.nextRetryNanos(m.WriteTimes(), nowNanos))
+	// Could not be written to any consumer, will retry later.
+	w.m.allConsumersWriteError.Inc(1)
+	return errFailAllConsumers
 }
 
 func (w *messageWriterImpl) nextRetryNanos(writeTimes int, nowNanos int64) int64 {
@@ -279,27 +290,41 @@ func (w *messageWriterImpl) retryUnacknowledged() {
 	var (
 		toBeRetried []*message
 		beforeRetry = w.nowFn()
+		batchSize   = w.opts.MessageRetryBatchSize()
 	)
 	for e != nil {
-		now := w.nowFn()
-		nowNanos := now.UnixNano()
+		beforeBatch := w.nowFn()
+		beforeBatchNanos := beforeBatch.UnixNano()
 		w.Lock()
-		e, toBeRetried = w.retryBatchWithLock(e, nowNanos)
+		e, toBeRetried = w.retryBatchWithLock(e, beforeBatchNanos, batchSize)
 		consumerWriters := w.consumerWriters
 		w.Unlock()
-		if len(consumerWriters) == 0 {
-			// Not expected in a healthy/valid placement.
-			w.m.noWritersError.Inc(int64(len(toBeRetried)))
-			w.m.retryBatchLatency.Record(w.nowFn().Sub(now))
-			continue
+		err := w.writeBatch(consumerWriters, toBeRetried)
+		w.m.retryBatchLatency.Record(w.nowFn().Sub(beforeBatch))
+		if err != nil {
+			// When we can't write to any consumer writer, skip the tick
+			// to avoid meaningless attempts, wait for next tick to retry.
+			break
 		}
-
-		for _, m := range toBeRetried {
-			w.write(consumerWriters, m)
-		}
-		w.m.retryBatchLatency.Record(w.nowFn().Sub(now))
 	}
 	w.m.retryTotalLatency.Record(w.nowFn().Sub(beforeRetry))
+}
+
+func (w *messageWriterImpl) writeBatch(
+	consumerWriters []consumerWriter,
+	toBeRetried []*message,
+) error {
+	if len(consumerWriters) == 0 {
+		// Not expected in a healthy/valid placement.
+		w.m.noWritersError.Inc(int64(len(toBeRetried)))
+		return errNoWriters
+	}
+	for _, m := range toBeRetried {
+		if err := w.write(consumerWriters, m); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // retryBatchWithLock iterates the message queue with a lock.
@@ -310,6 +335,7 @@ func (w *messageWriterImpl) retryUnacknowledged() {
 func (w *messageWriterImpl) retryBatchWithLock(
 	start *list.Element,
 	nowNanos int64,
+	batchSize int,
 ) (*list.Element, []*message) {
 	var (
 		iterated int
@@ -318,35 +344,46 @@ func (w *messageWriterImpl) retryBatchWithLock(
 	w.toBeRetried = w.toBeRetried[:0]
 	for e := start; e != nil; e = next {
 		iterated++
-		if iterated > w.opts.MessageRetryBatchSize() {
+		if iterated > batchSize {
 			break
 		}
 		next = e.Next()
 		m := e.Value.(*message)
-		if m.WriteTimes() == 0 {
-			w.acks.add(m.Metadata(), m)
-		}
 		if w.isClosed {
 			// Simply ack the messages here to mark them as consumed for this
 			// message writer, this is useful when user removes a consumer service
 			// during runtime that may be unhealthy to consume the messages.
 			// So that the unacked messages for the unhealthy consumer services
 			// do not stay in memory forever.
+			// NB: The message must be added to the ack map to be acked here.
 			w.Ack(m.Metadata())
-			w.queue.Remove(e)
-			w.close(m)
+			w.removeFromQueueWithLock(e, m)
+			w.m.messageClosed.Inc(1)
 			continue
 		}
 		if m.RetryAtNanos() >= nowNanos {
 			continue
 		}
-		if m.IsDroppedOrAcked() {
-			// Try removing the ack in case the message was dropped rather than acked.
-			w.acks.remove(m.Metadata())
-			w.queue.Remove(e)
-			w.close(m)
+		if m.Acked() {
+			w.removeFromQueueWithLock(e, m)
+			w.m.messageAcked.Inc(1)
 			continue
 		}
+		if m.IsDroppedOrConsumed() {
+			// There is a chance the message could be acked between m.Acked()
+			// and m.IsDroppedOrConsumed() check, in which case we should not
+			// mark it as dropped, just continue and next tick will remove it
+			// as acked.
+			if m.Acked() {
+				continue
+			}
+			w.acks.remove(m.Metadata())
+			w.removeFromQueueWithLock(e, m)
+			w.m.messageDropped.Inc(1)
+			continue
+		}
+		m.IncWriteTimes()
+		m.SetRetryAtNanos(w.nextRetryNanos(m.WriteTimes(), nowNanos))
 		w.toBeRetried = append(w.toBeRetried, m)
 	}
 	return next, w.toBeRetried
@@ -450,6 +487,11 @@ func (w *messageWriterImpl) newMessage() *message {
 		return w.mPool.Get()
 	}
 	return newMessage()
+}
+
+func (w *messageWriterImpl) removeFromQueueWithLock(e *list.Element, m *message) {
+	w.queue.Remove(e)
+	w.close(m)
 }
 
 func (w *messageWriterImpl) close(m *message) {

--- a/producer/writer/message_writer_test.go
+++ b/producer/writer/message_writer_test.go
@@ -28,12 +28,12 @@ import (
 
 	"github.com/m3db/m3msg/producer"
 	"github.com/m3db/m3msg/producer/msg"
+	"github.com/m3db/m3x/instrument"
 	"github.com/m3db/m3x/retry"
 
 	"github.com/fortytw2/leaktest"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
-	"github.com/uber-go/tally"
 )
 
 func TestMessageWriterWithPooling(t *testing.T) {
@@ -552,5 +552,5 @@ func testMessagePool(opts Options) messagePool {
 }
 
 func testMessageWriterMetrics() messageWriterMetrics {
-	return newMessageWriterMetrics(tally.NoopScope)
+	return newMessageWriterMetrics(instrument.NewOptions())
 }

--- a/producer/writer/message_writer_test.go
+++ b/producer/writer/message_writer_test.go
@@ -28,12 +28,12 @@ import (
 
 	"github.com/m3db/m3msg/producer"
 	"github.com/m3db/m3msg/producer/msg"
-	"github.com/m3db/m3x/instrument"
 	"github.com/m3db/m3x/retry"
 
 	"github.com/fortytw2/leaktest"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
 )
 
 func TestMessageWriterWithPooling(t *testing.T) {
@@ -552,5 +552,5 @@ func testMessagePool(opts Options) messagePool {
 }
 
 func testMessageWriterMetrics() messageWriterMetrics {
-	return newMessageWriterMetrics(instrument.NewOptions())
+	return newMessageWriterMetrics(tally.NoopScope, 1)
 }

--- a/producer/writer/message_writer_test.go
+++ b/producer/writer/message_writer_test.go
@@ -359,7 +359,7 @@ func TestMessageWriterCleanupDroppedMessage(t *testing.T) {
 
 	// A get will NOT allocate a new message because the old one has been returned to pool.
 	m = w.(*messageWriterImpl).mPool.Get()
-	require.True(t, m.IsDroppedOrAcked())
+	require.True(t, m.IsDroppedOrConsumed())
 }
 
 func TestMessageWriterCleanupAckedMessage(t *testing.T) {
@@ -440,7 +440,8 @@ func TestMessageWriterRetryIterateBatch(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	opts := testOptions().SetMessageRetryBatchSize(2).SetMessageRetryOptions(
+	retryBatchSize := 2
+	opts := testOptions().SetMessageRetryBatchSize(retryBatchSize).SetMessageRetryOptions(
 		retry.NewOptions().SetInitialBackoff(2 * time.Nanosecond).SetMaxBackoff(5 * time.Nanosecond),
 	)
 	w := newMessageWriter(200, testMessagePool(opts), opts, testMessageWriterMetrics()).(*messageWriterImpl)
@@ -464,7 +465,7 @@ func TestMessageWriterRetryIterateBatch(t *testing.T) {
 
 	md4.EXPECT().Finalize(gomock.Eq(producer.Dropped))
 	rd4.Drop()
-	e, toBeRetried := w.retryBatchWithLock(w.queue.Front(), w.nowFn().UnixNano())
+	e, toBeRetried := w.retryBatchWithLock(w.queue.Front(), w.nowFn().UnixNano(), retryBatchSize)
 	require.Equal(t, 2, len(toBeRetried))
 	for _, m := range toBeRetried {
 		m.SetRetryAtNanos(w.nowFn().Add(time.Hour).UnixNano())
@@ -474,19 +475,19 @@ func TestMessageWriterRetryIterateBatch(t *testing.T) {
 	require.Equal(t, []byte("3"), e.Value.(*message).RefCountedMessage.Bytes())
 
 	require.Equal(t, 4, w.queue.Len())
-	e, toBeRetried = w.retryBatchWithLock(e, w.nowFn().UnixNano())
+	e, toBeRetried = w.retryBatchWithLock(e, w.nowFn().UnixNano(), retryBatchSize)
 	require.Nil(t, e)
 	require.Equal(t, 1, len(toBeRetried))
 	require.Equal(t, 3, w.queue.Len())
 	for _, m := range toBeRetried {
 		m.SetRetryAtNanos(w.nowFn().Add(time.Hour).UnixNano())
 	}
-	e, toBeRetried = w.retryBatchWithLock(w.queue.Front(), w.nowFn().UnixNano())
+	e, toBeRetried = w.retryBatchWithLock(w.queue.Front(), w.nowFn().UnixNano(), retryBatchSize)
 	require.Equal(t, 0, len(toBeRetried))
 	// Make sure it stopped at rd3.
 	md3.EXPECT().Bytes().Return([]byte("3"))
 	require.Equal(t, []byte("3"), e.Value.(*message).RefCountedMessage.Bytes())
-	e, toBeRetried = w.retryBatchWithLock(e, w.nowFn().UnixNano())
+	e, toBeRetried = w.retryBatchWithLock(e, w.nowFn().UnixNano(), retryBatchSize)
 	require.Nil(t, e)
 	require.Equal(t, 0, len(toBeRetried))
 }
@@ -515,11 +516,11 @@ func TestNextRetryNanos(t *testing.T) {
 	require.True(t, retryAtNanos == nowNanos+2*int64(backoffDuration))
 }
 
-func TestMessageWriterCloseImmediately(t *testing.T) {
+func TestMessageWriterCloseCleanupAllMessages(t *testing.T) {
 	defer leaktest.Check(t)()
 
 	opts := testOptions()
-	w := newMessageWriter(200, nil, opts, testMessageWriterMetrics())
+	w := newMessageWriter(200, nil, opts, testMessageWriterMetrics()).(*messageWriterImpl)
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -530,12 +531,12 @@ func TestMessageWriterCloseImmediately(t *testing.T) {
 	mm.EXPECT().Finalize(producer.Consumed)
 	mm.EXPECT().Bytes().Return([]byte("foo"))
 	w.Write(rm)
-
-	require.Equal(t, 1, w.(*messageWriterImpl).queue.Len())
+	require.False(t, isEmptyWithLock(w.acks))
+	require.Equal(t, 1, w.queue.Len())
 	w.Init()
 	w.Close()
-	require.Equal(t, 0, w.(*messageWriterImpl).queue.Len())
-	require.True(t, isEmptyWithLock(w.(*messageWriterImpl).acks))
+	require.Equal(t, 0, w.queue.Len())
+	require.True(t, isEmptyWithLock(w.acks))
 }
 
 func isEmptyWithLock(h *acks) bool {

--- a/producer/writer/options.go
+++ b/producer/writer/options.go
@@ -39,7 +39,7 @@ const (
 	defaultCloseCheckInterval        = time.Second
 	defaultConnectionResetDelay      = 2 * time.Second
 	defaultMessageQueueScanInterval  = time.Second
-	defaultMessageRetryBatchSize     = 1024
+	defaultMessageRetryBatchSize     = 256
 	defaultInitialAckMapSize         = 1024
 	// Using 16K which provides much better performance comparing
 	// to lower values like 1k ~ 8k.

--- a/producer/writer/options.go
+++ b/producer/writer/options.go
@@ -39,7 +39,7 @@ const (
 	defaultCloseCheckInterval        = time.Second
 	defaultConnectionResetDelay      = 2 * time.Second
 	defaultMessageQueueScanInterval  = time.Second
-	defaultMessageRetryBatchSize     = 256
+	defaultMessageRetryBatchSize     = 64
 	defaultInitialAckMapSize         = 1024
 	// Using 16K which provides much better performance comparing
 	// to lower values like 1k ~ 8k.

--- a/producer/writer/shard_writer.go
+++ b/producer/writer/shard_writer.go
@@ -151,11 +151,10 @@ func newReplicatedShardWriter(
 
 func (w *replicatedShardWriter) Write(rm producer.RefCountedMessage) {
 	w.RLock()
-	mws := w.messageWriters
-	w.RUnlock()
-	for _, mw := range mws {
+	for _, mw := range w.messageWriters {
 		mw.Write(rm)
 	}
+	w.RUnlock()
 }
 
 // This is not thread safe, must be called in one thread.
@@ -263,11 +262,11 @@ func (w *replicatedShardWriter) Close() {
 func (w *replicatedShardWriter) QueueSize() int {
 	w.RLock()
 	mws := w.messageWriters
-	w.RUnlock()
 	var l int
 	for _, mw := range mws {
 		l += mw.QueueSize()
 	}
+	w.RUnlock()
 	return l
 }
 

--- a/producer/writer/writer.go
+++ b/producer/writer/writer.go
@@ -140,7 +140,7 @@ func (w *writer) Init() error {
 		SetProcessFn(w.processFn)
 	w.value = watch.NewValue(vOptions)
 	if err := w.value.Watch(); err != nil {
-		return fmt.Errorf("m3msg writer init error: %v", err)
+		return fmt.Errorf("writer init error: %v", err)
 	}
 	return nil
 }
@@ -189,6 +189,7 @@ func (w *writer) process(update interface{}) error {
 			continue
 		}
 		newConsumerServiceWriters[key] = csw
+		w.logger.Infof("initialized consumer service writer for %s", cs.String())
 	}
 	for key, csw := range w.consumerServiceWriters {
 		if _, ok := newConsumerServiceWriters[key]; !ok {


### PR DESCRIPTION
- Disallow non-sharded placement for a replicated consumer. non-sharded placement can only be used with shared consumption type because there is no shard distribution in the placement.
- When closing a consumer service, close all the shards concurrently. This is needed because when there are message unacked in a shard, the shard needs at least a tick to clean up all the messages, and a normal interval for tick is 1s, when there are 1024 shards, we could wait 1024s for the consumer service to be closed.
- In consumer writer, fail fast when the connection is not valid instead of trying to encode and then later realize the connection is broken, which wastes the encode CPU.
- In message writer, skip writing the tick when all of the consumer writers failed to write. This is to fail fast in the case when all the consumer instances in a consumer service could not be connected.
- Add metrics for message-acked, message-dropped for each consumer service

@xichen2020 @jeromefroe 