### PR TITLE
Change RefCountedMessage from interface to struct

### DIFF
--- a/producer/buffer/buffer_test.go
+++ b/producer/buffer/buffer_test.go
@@ -124,11 +124,11 @@ func TestCleanupBatch(t *testing.T) {
 
 	mm1.EXPECT().Finalize(gomock.Eq(producer.Dropped))
 	front := b.buffers.Front()
-	front.Value.(producer.RefCountedMessage).Drop()
+	front.Value.(*producer.RefCountedMessage).Drop()
 
 	require.Equal(t, 3, b.bufferLen())
 	e := b.cleanupBatchWithLock(front, 2)
-	require.Equal(t, 3, int(e.Value.(producer.RefCountedMessage).Size()))
+	require.Equal(t, 3, int(e.Value.(*producer.RefCountedMessage).Size()))
 	require.Equal(t, 2, b.bufferLen())
 
 	e = b.cleanupBatchWithLock(e, 2)
@@ -160,12 +160,12 @@ func TestCleanupBatchWithElementBeingRemovedByOtherThread(t *testing.T) {
 	require.NoError(t, err)
 
 	mm1.EXPECT().Finalize(gomock.Eq(producer.Dropped))
-	b.buffers.Front().Value.(producer.RefCountedMessage).Drop()
+	b.buffers.Front().Value.(*producer.RefCountedMessage).Drop()
 
 	require.Equal(t, 3, b.bufferLen())
 	e := b.cleanupBatchWithLock(b.buffers.Front(), 1)
 	// e stopped at message 2.
-	require.Equal(t, 2, int(e.Value.(producer.RefCountedMessage).Size()))
+	require.Equal(t, 2, int(e.Value.(*producer.RefCountedMessage).Size()))
 	require.Equal(t, 2, b.bufferLen())
 	require.NotNil(t, e)
 
@@ -177,7 +177,7 @@ func TestCleanupBatchWithElementBeingRemovedByOtherThread(t *testing.T) {
 
 	// Mark message 3 as dropped, so it's ready to be removed.
 	mm3.EXPECT().Finalize(gomock.Eq(producer.Dropped))
-	b.buffers.Front().Value.(producer.RefCountedMessage).Drop()
+	b.buffers.Front().Value.(*producer.RefCountedMessage).Drop()
 
 	// But next clean batch from the removed element is going to do nothing
 	// because the starting element is already removed.

--- a/producer/types.go
+++ b/producer/types.go
@@ -102,7 +102,7 @@ type Options interface {
 // Buffer buffers all the messages in the producer.
 type Buffer interface {
 	// Add adds message to the buffer and returns a reference counted message.
-	Add(m Message) (RefCountedMessage, error)
+	Add(m Message) (*RefCountedMessage, error)
 
 	// Init initializes the buffer.
 	Init()
@@ -116,7 +116,7 @@ type Buffer interface {
 // Writer writes all the messages out to the consumer services.
 type Writer interface {
 	// Write writes a reference counted message out.
-	Write(rm RefCountedMessage) error
+	Write(rm *RefCountedMessage) error
 
 	// RegisterFilter registers a filter to a consumer service.
 	RegisterFilter(sid services.ServiceID, fn FilterFunc)
@@ -129,38 +129,4 @@ type Writer interface {
 
 	// Close closes the writer.
 	Close()
-}
-
-// RefCountedMessage is a reference counted message.
-type RefCountedMessage interface {
-	// Shard returns the shard of the message.
-	Shard() uint32
-
-	// Bytes returns the bytes of the message.
-	Bytes() []byte
-
-	// Size returns the size of the message.
-	Size() uint64
-
-	// Accept returns true if the message can be accepted by the filter.
-	Accept(fn FilterFunc) bool
-
-	// IncRef increments the ref count.
-	IncRef()
-
-	// DecRef decrements the ref count. If the reference count became zero after
-	// the call, the message will be finalized as consumed.
-	DecRef()
-
-	// IncReads increments the reads count.
-	IncReads()
-
-	// DecReads decrements the reads count.
-	DecReads()
-
-	// Drop drops the message without waiting for it to be consumed.
-	Drop() bool
-
-	// IsDroppedOrConsumed returns true if the message has been dropped or consumed.
-	IsDroppedOrConsumed() bool
 }

--- a/producer/writer/consumer_service_writer.go
+++ b/producer/writer/consumer_service_writer.go
@@ -61,7 +61,7 @@ const (
 
 type consumerServiceWriter interface {
 	// Write writes a message.
-	Write(rm producer.RefCountedMessage)
+	Write(rm *producer.RefCountedMessage)
 
 	// Init will initialize the consumer service writer.
 	Init(initType) error
@@ -177,7 +177,7 @@ func initShardWriters(
 	return sws
 }
 
-func (w *consumerServiceWriterImpl) Write(rm producer.RefCountedMessage) {
+func (w *consumerServiceWriterImpl) Write(rm *producer.RefCountedMessage) {
 	if rm.Accept(w.dataFilter) {
 		w.shardWriters[rm.Shard()].Write(rm)
 		w.m.filterAccepted.Inc(1)

--- a/producer/writer/consumer_service_writer_mock.go
+++ b/producer/writer/consumer_service_writer_mock.go
@@ -50,7 +50,7 @@ func (_m *MockconsumerServiceWriter) EXPECT() *_MockconsumerServiceWriterRecorde
 	return _m.recorder
 }
 
-func (_m *MockconsumerServiceWriter) Write(rm producer.RefCountedMessage) {
+func (_m *MockconsumerServiceWriter) Write(rm *producer.RefCountedMessage) {
 	_m.ctrl.Call(_m, "Write", rm)
 }
 

--- a/producer/writer/consumer_service_writer_test.go
+++ b/producer/writer/consumer_service_writer_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/m3db/m3cluster/shard"
 	"github.com/m3db/m3msg/generated/proto/msgpb"
 	"github.com/m3db/m3msg/producer"
-	"github.com/m3db/m3msg/producer/msg"
 	"github.com/m3db/m3msg/protocol/proto"
 	"github.com/m3db/m3msg/topic"
 
@@ -123,7 +122,7 @@ func TestConsumerServiceWriterWithSharedConsumerWithNonShardedPlacement(t *testi
 	mm.EXPECT().Bytes().Return([]byte("foo"))
 	mm.EXPECT().Finalize(producer.Consumed)
 
-	rm := msg.NewRefCountedMessage(mm, nil)
+	rm := producer.NewRefCountedMessage(mm, nil)
 	csw.Write(rm)
 	for {
 		if rm.IsDroppedOrConsumed() {
@@ -258,7 +257,7 @@ func TestConsumerServiceWriterWithSharedConsumerWithShardedPlacement(t *testing.
 	mm.EXPECT().Bytes().Return([]byte("foo"))
 	mm.EXPECT().Finalize(producer.Consumed)
 
-	rm := msg.NewRefCountedMessage(mm, nil)
+	rm := producer.NewRefCountedMessage(mm, nil)
 	csw.Write(rm)
 	for {
 		if rm.IsDroppedOrConsumed() {
@@ -382,7 +381,7 @@ func TestConsumerServiceWriterWithReplicatedConsumerWithShardedPlacement(t *test
 	mm.EXPECT().Bytes().Return([]byte("foo")).AnyTimes()
 	mm.EXPECT().Finalize(producer.Consumed)
 
-	rm := msg.NewRefCountedMessage(mm, nil)
+	rm := producer.NewRefCountedMessage(mm, nil)
 	csw.Write(rm)
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -463,7 +462,7 @@ func TestConsumerServiceWriterWithReplicatedConsumerWithShardedPlacement(t *test
 	}()
 
 	mm.EXPECT().Finalize(producer.Consumed)
-	rm = msg.NewRefCountedMessage(mm, nil)
+	rm = producer.NewRefCountedMessage(mm, nil)
 	csw.Write(rm)
 	for {
 		if rm.IsDroppedOrConsumed() {
@@ -503,19 +502,19 @@ func TestConsumerServiceWriterFilter(t *testing.T) {
 	md1.EXPECT().Shard().Return(uint32(1)).AnyTimes()
 
 	sw0.EXPECT().Write(gomock.Any())
-	csw.Write(msg.NewRefCountedMessage(md0, nil))
+	csw.Write(producer.NewRefCountedMessage(md0, nil))
 	sw1.EXPECT().Write(gomock.Any())
-	csw.Write(msg.NewRefCountedMessage(md1, nil))
+	csw.Write(producer.NewRefCountedMessage(md1, nil))
 
 	csw.RegisterFilter(func(m producer.Message) bool { return m.Shard() == uint32(0) })
-	csw.Write(msg.NewRefCountedMessage(md1, nil))
+	csw.Write(producer.NewRefCountedMessage(md1, nil))
 
 	sw0.EXPECT().Write(gomock.Any())
-	csw.Write(msg.NewRefCountedMessage(md0, nil))
+	csw.Write(producer.NewRefCountedMessage(md0, nil))
 
 	csw.UnregisterFilter()
 	sw1.EXPECT().Write(gomock.Any())
-	csw.Write(msg.NewRefCountedMessage(md1, nil))
+	csw.Write(producer.NewRefCountedMessage(md1, nil))
 }
 
 func TestConsumerServiceWriterAllowInitValueErrorWithCreateWatchError(t *testing.T) {
@@ -638,7 +637,7 @@ func TestConsumerServiceCloseShardWritersConcurrently(t *testing.T) {
 		mm.EXPECT().Shard().Return(i)
 		mm.EXPECT().Bytes().Return(b).AnyTimes()
 		mm.EXPECT().Finalize(gomock.Any())
-		w.Write(msg.NewRefCountedMessage(mm, nil))
+		w.Write(producer.NewRefCountedMessage(mm, nil))
 	}
 
 	ch := make(chan struct{})

--- a/producer/writer/message.go
+++ b/producer/writer/message.go
@@ -29,7 +29,7 @@ import (
 )
 
 type message struct {
-	producer.RefCountedMessage
+	*producer.RefCountedMessage
 
 	pb           msgpb.Message
 	meta         metadata
@@ -49,7 +49,7 @@ func newMessage() *message {
 }
 
 // Set sets the message.
-func (m *message) Set(meta metadata, rm producer.RefCountedMessage) {
+func (m *message) Set(meta metadata, rm *producer.RefCountedMessage) {
 	m.meta = meta
 	m.RefCountedMessage = rm
 	m.ToProto(&m.pb)

--- a/producer/writer/message_pool_test.go
+++ b/producer/writer/message_pool_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/m3db/m3msg/generated/proto/msgpb"
 	"github.com/m3db/m3msg/producer"
-	"github.com/m3db/m3msg/producer/msg"
 	"github.com/m3db/m3x/pool"
 
 	"github.com/golang/mock/gomock"
@@ -40,7 +39,7 @@ func TestMessagePool(t *testing.T) {
 	defer ctrl.Finish()
 
 	mm := producer.NewMockMessage(ctrl)
-	rm := msg.NewRefCountedMessage(mm, nil)
+	rm := producer.NewRefCountedMessage(mm, nil)
 	rm.IncRef()
 
 	m := p.Get()
@@ -62,6 +61,6 @@ func TestMessagePool(t *testing.T) {
 	require.True(t, m.IsDroppedOrConsumed())
 
 	mm.EXPECT().Bytes().Return([]byte("foo"))
-	m.Set(metadata{}, msg.NewRefCountedMessage(mm, nil))
+	m.Set(metadata{}, producer.NewRefCountedMessage(mm, nil))
 	require.False(t, m.IsDroppedOrConsumed())
 }

--- a/producer/writer/message_writer.go
+++ b/producer/writer/message_writer.go
@@ -42,7 +42,7 @@ var (
 
 type messageWriter interface {
 	// Write writes the message.
-	Write(rm producer.RefCountedMessage)
+	Write(rm *producer.RefCountedMessage)
 
 	// Ack acknowledges the metadata.
 	Ack(meta metadata)
@@ -172,7 +172,7 @@ func newMessageWriter(
 	}
 }
 
-func (w *messageWriterImpl) Write(rm producer.RefCountedMessage) {
+func (w *messageWriterImpl) Write(rm *producer.RefCountedMessage) {
 	var (
 		nowNanos = w.nowFn().UnixNano()
 		msg      = w.newMessage()

--- a/producer/writer/message_writer_test.go
+++ b/producer/writer/message_writer_test.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/m3db/m3msg/producer"
-	"github.com/m3db/m3msg/producer/msg"
 	"github.com/m3db/m3x/retry"
 
 	"github.com/fortytw2/leaktest"
@@ -75,7 +74,7 @@ func TestMessageWriterWithPooling(t *testing.T) {
 	md1.EXPECT().Bytes().Return([]byte("foo")).Times(1)
 	md1.EXPECT().Finalize(producer.Consumed)
 
-	w.Write(msg.NewRefCountedMessage(md1, nil))
+	w.Write(producer.NewRefCountedMessage(md1, nil))
 
 	for {
 		w.RLock()
@@ -92,7 +91,7 @@ func TestMessageWriterWithPooling(t *testing.T) {
 	md2 := producer.NewMockMessage(ctrl)
 	md2.EXPECT().Bytes().Return([]byte("bar")).Times(1)
 
-	w.Write(msg.NewRefCountedMessage(md2, nil))
+	w.Write(producer.NewRefCountedMessage(md2, nil))
 	for {
 		if !isEmptyWithLock(w.acks) {
 			break
@@ -156,7 +155,7 @@ func TestMessageWriterWithoutPooling(t *testing.T) {
 	md1.EXPECT().Bytes().Return([]byte("foo")).Times(1)
 	md1.EXPECT().Finalize(producer.Consumed)
 
-	w.Write(msg.NewRefCountedMessage(md1, nil))
+	w.Write(producer.NewRefCountedMessage(md1, nil))
 
 	for {
 		w.RLock()
@@ -173,7 +172,7 @@ func TestMessageWriterWithoutPooling(t *testing.T) {
 	md2 := producer.NewMockMessage(ctrl)
 	md2.EXPECT().Bytes().Return([]byte("bar")).Times(1)
 
-	w.Write(msg.NewRefCountedMessage(md2, nil))
+	w.Write(producer.NewRefCountedMessage(md2, nil))
 	for {
 		if !isEmptyWithLock(w.acks) {
 			break
@@ -221,7 +220,7 @@ func TestMessageWriterRetryWithoutPooling(t *testing.T) {
 	mm.EXPECT().Bytes().Return([]byte("foo")).AnyTimes()
 	mm.EXPECT().Finalize(producer.Consumed)
 
-	rm := msg.NewRefCountedMessage(mm, nil)
+	rm := producer.NewRefCountedMessage(mm, nil)
 	w.Write(rm)
 
 	w.AddConsumerWriter(newConsumerWriter("bad", a, opts, testConsumerWriterMetrics()))
@@ -280,7 +279,7 @@ func TestMessageWriterRetryWithPooling(t *testing.T) {
 	mm.EXPECT().Bytes().Return([]byte("foo")).AnyTimes()
 	mm.EXPECT().Finalize(producer.Consumed)
 
-	rm := msg.NewRefCountedMessage(mm, nil)
+	rm := producer.NewRefCountedMessage(mm, nil)
 	w.Write(rm)
 
 	w.AddConsumerWriter(newConsumerWriter("bad", a, opts, testConsumerWriterMetrics()))
@@ -332,7 +331,7 @@ func TestMessageWriterCleanupDroppedMessage(t *testing.T) {
 
 	mm := producer.NewMockMessage(ctrl)
 
-	rm := msg.NewRefCountedMessage(mm, nil)
+	rm := producer.NewRefCountedMessage(mm, nil)
 	mm.EXPECT().Finalize(producer.Dropped)
 	rm.Drop()
 	mm.EXPECT().Bytes().Return([]byte("foo"))
@@ -376,7 +375,7 @@ func TestMessageWriterCleanupAckedMessage(t *testing.T) {
 	mm := producer.NewMockMessage(ctrl)
 	mm.EXPECT().Bytes().Return([]byte("foo"))
 
-	rm := msg.NewRefCountedMessage(mm, nil)
+	rm := producer.NewRefCountedMessage(mm, nil)
 	// Another message write also holds this message.
 	rm.IncRef()
 
@@ -432,7 +431,7 @@ func TestMessageWriterCutoverCutoff(t *testing.T) {
 	require.False(t, w.isValidWriteWithLock(now.UnixNano()+250))
 	require.False(t, w.isValidWriteWithLock(now.UnixNano()+50))
 	require.Equal(t, 0, w.queue.Len())
-	w.Write(msg.NewRefCountedMessage(nil, nil))
+	w.Write(producer.NewRefCountedMessage(nil, nil))
 	require.Equal(t, 0, w.queue.Len())
 }
 
@@ -450,10 +449,10 @@ func TestMessageWriterRetryIterateBatch(t *testing.T) {
 	md2 := producer.NewMockMessage(ctrl)
 	md3 := producer.NewMockMessage(ctrl)
 	md4 := producer.NewMockMessage(ctrl)
-	rd1 := msg.NewRefCountedMessage(md1, nil)
-	rd2 := msg.NewRefCountedMessage(md2, nil)
-	rd3 := msg.NewRefCountedMessage(md3, nil)
-	rd4 := msg.NewRefCountedMessage(md4, nil)
+	rd1 := producer.NewRefCountedMessage(md1, nil)
+	rd2 := producer.NewRefCountedMessage(md2, nil)
+	rd3 := producer.NewRefCountedMessage(md3, nil)
+	rd4 := producer.NewRefCountedMessage(md4, nil)
 	md1.EXPECT().Bytes().Return([]byte("1"))
 	md2.EXPECT().Bytes().Return([]byte("2"))
 	md3.EXPECT().Bytes().Return([]byte("3"))
@@ -527,7 +526,7 @@ func TestMessageWriterCloseCleanupAllMessages(t *testing.T) {
 
 	mm := producer.NewMockMessage(ctrl)
 
-	rm := msg.NewRefCountedMessage(mm, nil)
+	rm := producer.NewRefCountedMessage(mm, nil)
 	mm.EXPECT().Finalize(producer.Consumed)
 	mm.EXPECT().Bytes().Return([]byte("foo"))
 	w.Write(rm)

--- a/producer/writer/shard_writer.go
+++ b/producer/writer/shard_writer.go
@@ -32,7 +32,7 @@ import (
 
 type shardWriter interface {
 	// Write writes the reference counted message, this needs to be thread safe.
-	Write(rm producer.RefCountedMessage)
+	Write(rm *producer.RefCountedMessage)
 
 	// UpdateInstances updates the instances responsible for this shard.
 	UpdateInstances(
@@ -71,7 +71,7 @@ func newSharedShardWriter(
 	}
 }
 
-func (w *sharedShardWriter) Write(rm producer.RefCountedMessage) {
+func (w *sharedShardWriter) Write(rm *producer.RefCountedMessage) {
 	w.mw.Write(rm)
 }
 
@@ -149,7 +149,7 @@ func newReplicatedShardWriter(
 	}
 }
 
-func (w *replicatedShardWriter) Write(rm producer.RefCountedMessage) {
+func (w *replicatedShardWriter) Write(rm *producer.RefCountedMessage) {
 	w.RLock()
 	for _, mw := range w.messageWriters {
 		mw.Write(rm)

--- a/producer/writer/shard_writer_mock.go
+++ b/producer/writer/shard_writer_mock.go
@@ -51,7 +51,7 @@ func (_m *MockshardWriter) EXPECT() *_MockshardWriterRecorder {
 	return _m.recorder
 }
 
-func (_m *MockshardWriter) Write(rm producer.RefCountedMessage) {
+func (_m *MockshardWriter) Write(rm *producer.RefCountedMessage) {
 	_m.ctrl.Call(_m, "Write", rm)
 }
 

--- a/producer/writer/shard_writer_test.go
+++ b/producer/writer/shard_writer_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/m3db/m3cluster/shard"
 	"github.com/m3db/m3msg/generated/proto/msgpb"
 	"github.com/m3db/m3msg/producer"
-	"github.com/m3db/m3msg/producer/msg"
 	"github.com/m3db/m3msg/protocol/proto"
 
 	"github.com/fortytw2/leaktest"
@@ -87,7 +86,7 @@ func TestSharedShardWriter(t *testing.T) {
 	mm.EXPECT().Bytes().Return([]byte("foo"))
 	mm.EXPECT().Finalize(producer.Consumed)
 
-	sw.Write(msg.NewRefCountedMessage(mm, nil))
+	sw.Write(producer.NewRefCountedMessage(mm, nil))
 
 	mw := sw.(*sharedShardWriter).mw.(*messageWriterImpl)
 	mw.RLock()
@@ -169,7 +168,7 @@ func TestReplicatedShardWriter(t *testing.T) {
 	mm := producer.NewMockMessage(ctrl)
 	mm.EXPECT().Bytes().Return([]byte("foo")).Times(2)
 
-	sw.Write(msg.NewRefCountedMessage(mm, nil))
+	sw.Write(producer.NewRefCountedMessage(mm, nil))
 
 	mw1 := sw.messageWriters[i1.Endpoint()].(*messageWriterImpl)
 	require.Equal(t, 1, mw1.queue.Len())
@@ -277,7 +276,7 @@ func TestReplicatedShardWriterRemoveMessageWriter(t *testing.T) {
 	mm := producer.NewMockMessage(ctrl)
 	mm.EXPECT().Bytes().Return([]byte("foo")).Times(2)
 
-	sw.Write(msg.NewRefCountedMessage(mm, nil))
+	sw.Write(producer.NewRefCountedMessage(mm, nil))
 	require.Equal(t, 1, mw1.queue.Len())
 	require.Equal(t, 1, mw2.queue.Len())
 

--- a/producer/writer/writer.go
+++ b/producer/writer/writer.go
@@ -94,7 +94,7 @@ func NewWriter(opts Options) producer.Writer {
 	return w
 }
 
-func (w *writer) Write(rm producer.RefCountedMessage) error {
+func (w *writer) Write(rm *producer.RefCountedMessage) error {
 	w.RLock()
 	if w.isClosed {
 		rm.Drop()

--- a/producer/writer/writer_test.go
+++ b/producer/writer/writer_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/m3db/m3cluster/services"
 	"github.com/m3db/m3cluster/shard"
 	"github.com/m3db/m3msg/producer"
-	"github.com/m3db/m3msg/producer/msg"
 	"github.com/m3db/m3msg/topic"
 
 	"github.com/fortytw2/leaktest"
@@ -82,7 +81,7 @@ func TestWriterWriteAfterClosed(t *testing.T) {
 
 	mm := producer.NewMockMessage(ctrl)
 	mm.EXPECT().Finalize(producer.Dropped)
-	rm := msg.NewRefCountedMessage(mm, nil)
+	rm := producer.NewRefCountedMessage(mm, nil)
 	err = w.Write(rm)
 	require.Error(t, err)
 	require.Equal(t, errWriterClosed, err)
@@ -108,13 +107,13 @@ func TestWriterWriteWithInvalidShard(t *testing.T) {
 	mm := producer.NewMockMessage(ctrl)
 	mm.EXPECT().Shard().Return(uint32(2))
 	mm.EXPECT().Finalize(producer.Dropped)
-	rm := msg.NewRefCountedMessage(mm, nil)
+	rm := producer.NewRefCountedMessage(mm, nil)
 	err = w.Write(rm)
 	require.Error(t, err)
 
 	mm.EXPECT().Shard().Return(uint32(100))
 	mm.EXPECT().Finalize(producer.Dropped)
-	rm = msg.NewRefCountedMessage(mm, nil)
+	rm = producer.NewRefCountedMessage(mm, nil)
 	err = w.Write(rm)
 	require.Error(t, err)
 }
@@ -546,7 +545,7 @@ func TestWriterWrite(t *testing.T) {
 	mm.EXPECT().Shard().Return(uint32(0)).Times(3)
 	mm.EXPECT().Bytes().Return([]byte("foo")).Times(3)
 	mm.EXPECT().Finalize(producer.Consumed).Do(func(interface{}) { wg.Done() })
-	rm := msg.NewRefCountedMessage(mm, nil)
+	rm := producer.NewRefCountedMessage(mm, nil)
 	wg.Add(1)
 	require.NoError(t, w.Write(rm))
 
@@ -623,7 +622,7 @@ func TestWriterCloseBlocking(t *testing.T) {
 	mm.EXPECT().Shard().Return(uint32(0)).Times(2)
 	mm.EXPECT().Bytes().Return([]byte("foo")).Times(1)
 	mm.EXPECT().Finalize(producer.Dropped)
-	rm := msg.NewRefCountedMessage(mm, nil)
+	rm := producer.NewRefCountedMessage(mm, nil)
 	require.NoError(t, w.Write(rm))
 
 	doneCh := make(chan struct{})


### PR DESCRIPTION
When scanning the list in buffer, we had to do a lot of type conversion to get the message in each list.Element, and assertE2T is much cheaper than assertE2I

@xichen2020 