### PR TITLE
Add retrier for buffer scan

### DIFF
--- a/integration/setup.go
+++ b/integration/setup.go
@@ -530,8 +530,10 @@ func testProducer(
 ) producer.Producer {
 	str := `
 buffer:
-  cleanupInterval: 200ms
   closeCheckInterval: 200ms
+  cleanupRetry:
+    initialBackoff: 100ms
+    maxBackoff: 200ms
 writer:
   topicName: topicName
   topicWatchInitTimeout: 100ms

--- a/producer/buffer/buffer_test.go
+++ b/producer/buffer/buffer_test.go
@@ -107,13 +107,13 @@ func TestCleanupBatch(t *testing.T) {
 	defer ctrl.Finish()
 
 	mm1 := producer.NewMockMessage(ctrl)
-	mm1.EXPECT().Size().Return(uint32(1)).Times(2)
+	mm1.EXPECT().Size().Return(uint32(1)).AnyTimes()
 
 	mm2 := producer.NewMockMessage(ctrl)
-	mm2.EXPECT().Size().Return(uint32(2))
+	mm2.EXPECT().Size().Return(uint32(2)).AnyTimes()
 
 	mm3 := producer.NewMockMessage(ctrl)
-	mm3.EXPECT().Size().Return(uint32(3)).Times(2)
+	mm3.EXPECT().Size().Return(uint32(3)).AnyTimes()
 
 	b := NewBuffer(NewOptions().SetScanBatchSize(2)).(*buffer)
 	_, err := b.Add(mm1)

--- a/producer/buffer/options.go
+++ b/producer/buffer/options.go
@@ -38,11 +38,6 @@ const (
 )
 
 var (
-	defaultCleanupRetryOptions = retry.NewOptions().
-					SetInitialBackoff(defaultCleanupInitialBackoff).
-					SetMaxBackoff(defaultCleanupMaxBackoff).
-					SetForever(true)
-
 	errInvalidMaxMessageSize = errors.New("invalid max message size")
 )
 
@@ -64,8 +59,11 @@ func NewOptions() Options {
 		maxMessageSize:     defaultMaxMessageSize,
 		closeCheckInterval: defaultCloseCheckInterval,
 		scanBatchSize:      defaultScanBatchSize,
-		rOpts:              defaultCleanupRetryOptions,
-		iOpts:              instrument.NewOptions(),
+		rOpts: retry.NewOptions().
+			SetInitialBackoff(defaultCleanupInitialBackoff).
+			SetMaxBackoff(defaultCleanupMaxBackoff).
+			SetForever(true),
+		iOpts: instrument.NewOptions(),
 	}
 }
 

--- a/producer/buffer/types.go
+++ b/producer/buffer/types.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/m3db/m3x/instrument"
+	"github.com/m3db/m3x/retry"
 )
 
 // OnFullStrategy defines the buffer behavior when the buffer is full.
@@ -60,12 +61,6 @@ type Options interface {
 	// SetMaxBufferSize sets the max buffer size.
 	SetMaxBufferSize(value int) Options
 
-	// CleanupInterval returns the cleanup interval.
-	CleanupInterval() time.Duration
-
-	// SetCleanupInterval sets the cleanup interval.
-	SetCleanupInterval(value time.Duration) Options
-
 	// CloseCheckInterval returns the close check interval.
 	CloseCheckInterval() time.Duration
 
@@ -77,6 +72,12 @@ type Options interface {
 
 	// SetScanBatchSize sets the scan batch size.
 	SetScanBatchSize(value int) Options
+
+	// CleanupRetryOptions returns the cleanup retry options.
+	CleanupRetryOptions() retry.Options
+
+	// SetCleanupRetryOptions sets the cleanup retry options.
+	SetCleanupRetryOptions(value retry.Options) Options
 
 	// InstrumentOptions returns the instrument options.
 	InstrumentOptions() instrument.Options

--- a/producer/buffer/types.go
+++ b/producer/buffer/types.go
@@ -84,4 +84,7 @@ type Options interface {
 
 	// SetInstrumentOptions sets the instrument options.
 	SetInstrumentOptions(value instrument.Options) Options
+
+	// Validate validates the options.
+	Validate() error
 }

--- a/producer/config/buffer.go
+++ b/producer/config/buffer.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/m3db/m3msg/producer/buffer"
 	"github.com/m3db/m3x/instrument"
+	"github.com/m3db/m3x/retry"
 )
 
 // BufferConfiguration configs the buffer.
@@ -32,9 +33,9 @@ type BufferConfiguration struct {
 	OnFullStrategy     *buffer.OnFullStrategy `yaml:"onFullStrategy"`
 	MaxBufferSize      *int                   `yaml:"maxBufferSize"`
 	MaxMessageSize     *int                   `yaml:"maxMessageSize"`
-	CleanupInterval    *time.Duration         `yaml:"cleanupInterval"`
 	CloseCheckInterval *time.Duration         `yaml:"closeCheckInterval"`
 	ScanBatchSize      *int                   `yaml:"scanBatchSize"`
+	CleanupRetry       *retry.Configuration   `yaml:"cleanupRetry"`
 }
 
 // NewOptions creates new buffer options.
@@ -46,9 +47,6 @@ func (c *BufferConfiguration) NewOptions(iOpts instrument.Options) buffer.Option
 	if c.MaxMessageSize != nil {
 		opts = opts.SetMaxMessageSize(*c.MaxMessageSize)
 	}
-	if c.CleanupInterval != nil {
-		opts = opts.SetCleanupInterval(*c.CleanupInterval)
-	}
 	if c.CloseCheckInterval != nil {
 		opts = opts.SetCloseCheckInterval(*c.CloseCheckInterval)
 	}
@@ -57,6 +55,9 @@ func (c *BufferConfiguration) NewOptions(iOpts instrument.Options) buffer.Option
 	}
 	if c.ScanBatchSize != nil {
 		opts = opts.SetScanBatchSize(*c.ScanBatchSize)
+	}
+	if c.CleanupRetry != nil {
+		opts = opts.SetCleanupRetryOptions(c.CleanupRetry.NewOptions(iOpts.MetricsScope()))
 	}
 	return opts.SetInstrumentOptions(iOpts)
 }

--- a/producer/config/buffer_test.go
+++ b/producer/config/buffer_test.go
@@ -36,19 +36,20 @@ func TestBufferConfiguration(t *testing.T) {
 onFullStrategy: returnError
 maxBufferSize: 100
 maxMessageSize: 16
-cleanupInterval: 2s
 closeCheckInterval: 3s
 scanBatchSize: 128
+cleanupRetry:
+  initialBackoff: 2s
 `
 
 	var cfg BufferConfiguration
 	require.NoError(t, yaml.Unmarshal([]byte(str), &cfg))
 
-	bOpts := cfg.NewOptions(nil)
+	bOpts := cfg.NewOptions(instrument.NewOptions())
 	require.Equal(t, buffer.ReturnError, bOpts.OnFullStrategy())
 	require.Equal(t, 100, bOpts.MaxBufferSize())
 	require.Equal(t, 16, bOpts.MaxMessageSize())
-	require.Equal(t, 2*time.Second, bOpts.CleanupInterval())
+	require.Equal(t, 2*time.Second, bOpts.CleanupRetryOptions().InitialBackoff())
 	require.Equal(t, 3*time.Second, bOpts.CloseCheckInterval())
 	require.Equal(t, 128, bOpts.ScanBatchSize())
 }

--- a/producer/config/buffer_test.go
+++ b/producer/config/buffer_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/m3db/m3msg/producer/buffer"
 	"github.com/m3db/m3x/instrument"
+	"github.com/m3db/m3x/retry"
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
@@ -58,5 +59,9 @@ func TestEmptyBufferConfiguration(t *testing.T) {
 	var cfg BufferConfiguration
 	require.NoError(t, yaml.Unmarshal(nil, &cfg))
 	require.Equal(t, BufferConfiguration{}, cfg)
-	require.Equal(t, buffer.NewOptions(), cfg.NewOptions(instrument.NewOptions()))
+	rOpts := retry.NewOptions()
+	require.Equal(t,
+		buffer.NewOptions().SetCleanupRetryOptions(rOpts),
+		cfg.NewOptions(instrument.NewOptions()).SetCleanupRetryOptions(rOpts),
+	)
 }

--- a/producer/config/producer.go
+++ b/producer/config/producer.go
@@ -42,8 +42,12 @@ func (c *ProducerConfiguration) newOptions(
 	if err != nil {
 		return nil, err
 	}
+	b, err := buffer.NewBuffer(c.Buffer.NewOptions(iOpts))
+	if err != nil {
+		return nil, err
+	}
 	return producer.NewOptions().
-		SetBuffer(buffer.NewBuffer(c.Buffer.NewOptions(iOpts))).
+		SetBuffer(b).
 		SetWriter(writer.NewWriter(wOpts)), nil
 }
 

--- a/producer/config/producer_test.go
+++ b/producer/config/producer_test.go
@@ -34,6 +34,7 @@ import (
 func TestProducerConfiguration(t *testing.T) {
 	str := `
 buffer:
+  maxMessageSize: 10
   maxBufferSize: 100
 writer:
   topicName: testTopic

--- a/producer/ref_counted.go
+++ b/producer/ref_counted.go
@@ -34,6 +34,7 @@ type RefCountedMessage struct {
 	sync.RWMutex
 	Message
 
+	size         uint64
 	onFinalizeFn OnFinalizeFn
 
 	refCount            *atomic.Int32
@@ -45,6 +46,7 @@ func NewRefCountedMessage(m Message, fn OnFinalizeFn) *RefCountedMessage {
 	return &RefCountedMessage{
 		Message:             m,
 		refCount:            atomic.NewInt32(0),
+		size:                uint64(m.Size()),
 		onFinalizeFn:        fn,
 		isDroppedOrConsumed: atomic.NewBool(false),
 	}
@@ -84,7 +86,7 @@ func (rm *RefCountedMessage) DecReads() {
 
 // Size returns the size of the message.
 func (rm *RefCountedMessage) Size() uint64 {
-	return uint64(rm.Message.Size())
+	return rm.size
 }
 
 // Drop drops the message without waiting for it to be consumed.

--- a/producer/ref_counted_test.go
+++ b/producer/ref_counted_test.go
@@ -82,6 +82,7 @@ func TestRefCountedMessageBytesReadBlocking(t *testing.T) {
 
 	mm := NewMockMessage(ctrl)
 	mockBytes := []byte("foo")
+	mm.EXPECT().Size().Return(uint32(3))
 	mm.EXPECT().Bytes().Return(mockBytes)
 
 	rm := NewRefCountedMessage(mm, nil)
@@ -108,7 +109,12 @@ func TestRefCountedMessageBytesReadBlocking(t *testing.T) {
 }
 
 func TestRefCountedMessageDecPanic(t *testing.T) {
-	rm := NewRefCountedMessage(nil, nil)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mm := NewMockMessage(ctrl)
+	mm.EXPECT().Size().Return(uint32(0))
+	rm := NewRefCountedMessage(mm, nil)
 	require.Panics(t, rm.DecRef)
 }
 
@@ -123,6 +129,7 @@ func TestRefCountedMessageFilter(t *testing.T) {
 	}
 
 	mm := NewMockMessage(ctrl)
+	mm.EXPECT().Size().Return(uint32(0))
 	rm := NewRefCountedMessage(mm, nil)
 
 	mm.EXPECT().Shard().Return(uint32(0))
@@ -137,6 +144,7 @@ func TestRefCountedMessageOnDropFn(t *testing.T) {
 	defer ctrl.Finish()
 
 	mm := NewMockMessage(ctrl)
+	mm.EXPECT().Size().Return(uint32(0))
 	mm.EXPECT().Finalize(Dropped)
 
 	var called int
@@ -156,6 +164,7 @@ func TestRefCountedMessageNoBlocking(t *testing.T) {
 	defer ctrl.Finish()
 
 	mm := NewMockMessage(ctrl)
+	mm.EXPECT().Size().Return(uint32(0)).AnyTimes()
 	for i := 0; i < 10000; i++ {
 		rm := NewRefCountedMessage(mm, nil)
 		var wg sync.WaitGroup

--- a/producer/writer/message.go
+++ b/producer/writer/message.go
@@ -60,6 +60,7 @@ func (m *message) Close() {
 	m.retryAtNanos = 0
 	m.retried = 0
 	m.isAcked.Store(false)
+	m.ResetProto(&m.pb)
 }
 
 // RetryAtNanos returns the timestamp for next retry in nano seconds.
@@ -106,4 +107,8 @@ func (m *message) Marshaler() (proto.Marshaler, bool) {
 func (m *message) ToProto(pb *msgpb.Message) {
 	m.meta.ToProto(&pb.Metadata)
 	pb.Value = m.RefCountedMessage.Bytes()
+}
+
+func (m *message) ResetProto(pb *msgpb.Message) {
+	pb.Value = nil
 }

--- a/producer/writer/options.go
+++ b/producer/writer/options.go
@@ -39,7 +39,7 @@ const (
 	defaultCloseCheckInterval        = time.Second
 	defaultConnectionResetDelay      = 2 * time.Second
 	defaultMessageQueueScanInterval  = time.Second
-	defaultMessageRetryBatchSize     = 64
+	defaultMessageRetryBatchSize     = 16
 	defaultInitialAckMapSize         = 1024
 	// Using 16K which provides much better performance comparing
 	// to lower values like 1k ~ 8k.

--- a/producer/writer/shard_writer_test.go
+++ b/producer/writer/shard_writer_test.go
@@ -85,6 +85,7 @@ func TestSharedShardWriter(t *testing.T) {
 	mm := producer.NewMockMessage(ctrl)
 	mm.EXPECT().Bytes().Return([]byte("foo"))
 	mm.EXPECT().Finalize(producer.Consumed)
+	mm.EXPECT().Size().Return(uint32(3))
 
 	sw.Write(producer.NewRefCountedMessage(mm, nil))
 
@@ -166,6 +167,7 @@ func TestReplicatedShardWriter(t *testing.T) {
 	defer ctrl.Finish()
 
 	mm := producer.NewMockMessage(ctrl)
+	mm.EXPECT().Size().Return(uint32(3))
 	mm.EXPECT().Bytes().Return([]byte("foo")).Times(2)
 
 	sw.Write(producer.NewRefCountedMessage(mm, nil))
@@ -274,6 +276,7 @@ func TestReplicatedShardWriterRemoveMessageWriter(t *testing.T) {
 	defer ctrl.Finish()
 
 	mm := producer.NewMockMessage(ctrl)
+	mm.EXPECT().Size().Return(uint32(3))
 	mm.EXPECT().Bytes().Return([]byte("foo")).Times(2)
 
 	sw.Write(producer.NewRefCountedMessage(mm, nil))

--- a/producer/writer/writer_test.go
+++ b/producer/writer/writer_test.go
@@ -81,6 +81,7 @@ func TestWriterWriteAfterClosed(t *testing.T) {
 
 	mm := producer.NewMockMessage(ctrl)
 	mm.EXPECT().Finalize(producer.Dropped)
+	mm.EXPECT().Size().Return(uint32(3))
 	rm := producer.NewRefCountedMessage(mm, nil)
 	err = w.Write(rm)
 	require.Error(t, err)
@@ -107,12 +108,14 @@ func TestWriterWriteWithInvalidShard(t *testing.T) {
 	mm := producer.NewMockMessage(ctrl)
 	mm.EXPECT().Shard().Return(uint32(2))
 	mm.EXPECT().Finalize(producer.Dropped)
+	mm.EXPECT().Size().Return(uint32(3))
 	rm := producer.NewRefCountedMessage(mm, nil)
 	err = w.Write(rm)
 	require.Error(t, err)
 
 	mm.EXPECT().Shard().Return(uint32(100))
 	mm.EXPECT().Finalize(producer.Dropped)
+	mm.EXPECT().Size().Return(uint32(3))
 	rm = producer.NewRefCountedMessage(mm, nil)
 	err = w.Write(rm)
 	require.Error(t, err)
@@ -543,6 +546,7 @@ func TestWriterWrite(t *testing.T) {
 	var wg sync.WaitGroup
 	mm := producer.NewMockMessage(ctrl)
 	mm.EXPECT().Shard().Return(uint32(0)).Times(3)
+	mm.EXPECT().Size().Return(uint32(3))
 	mm.EXPECT().Bytes().Return([]byte("foo")).Times(3)
 	mm.EXPECT().Finalize(producer.Consumed).Do(func(interface{}) { wg.Done() })
 	rm := producer.NewRefCountedMessage(mm, nil)
@@ -619,6 +623,7 @@ func TestWriterCloseBlocking(t *testing.T) {
 	require.Equal(t, 1, len(w.consumerServiceWriters))
 
 	mm := producer.NewMockMessage(ctrl)
+	mm.EXPECT().Size().Return(uint32(3))
 	mm.EXPECT().Shard().Return(uint32(0)).Times(2)
 	mm.EXPECT().Bytes().Return([]byte("foo")).Times(1)
 	mm.EXPECT().Finalize(producer.Dropped)


### PR DESCRIPTION
Add a retrier in buffer scanning, add backoff when nothing is being consumed, aka nothing to be removed.

@xichen2020 @jeromefroe 