### PR TITLE
Use int instead of uint32 for message size type

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 72d8bc94c4e5c219966ac2c7b18a169e2cd3e47b872ef940b4a5330822ed8ab5
-updated: 2018-06-03T23:32:33.341349-04:00
+hash: ad49256c7523c990892d0deeffafdad7340d6537973410a37b8840fea8d2d519
+updated: 2018-06-19T10:38:09.058936-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -37,7 +37,7 @@ imports:
   - cmp/internal/function
   - cmp/internal/value
 - name: github.com/m3db/m3cluster
-  version: cb17a54d6902c03790286942bafa04a188d4eeb8
+  version: 932643c994584dc8830cdc6434fd5545768d9f29
   subpackages:
   - client
   - generated/proto/metadatapb
@@ -54,7 +54,7 @@ imports:
   - services/leader/campaign
   - shard
 - name: github.com/m3db/m3x
-  version: 782ecfe679d9bb930a06b6c97f632caa1bb14494
+  version: 647a4a05078f018242070cbd71bea6ecba964199
   subpackages:
   - checked
   - clock
@@ -97,7 +97,7 @@ imports:
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: 12b6f73e6084dad08a7c6e575284b177ecafbc71
+  version: f35b8ab0b5a2cef36673838d662e249dd9c94686
   subpackages:
   - assert
   - require

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,9 +1,9 @@
 package: github.com/m3db/m3msg
 import:
 - package: github.com/m3db/m3x
-  version: 782ecfe679d9bb930a06b6c97f632caa1bb14494
+  version: 647a4a05078f018242070cbd71bea6ecba964199
 - package: github.com/m3db/m3cluster
-  version: cb17a54d6902c03790286942bafa04a188d4eeb8
+  version: 932643c994584dc8830cdc6434fd5545768d9f29
 - package: github.com/golang/protobuf
   version: v1.0.0
 - package: github.com/gogo/protobuf

--- a/integration/setup.go
+++ b/integration/setup.go
@@ -190,7 +190,7 @@ func (s *setup) Run(
 		for j := 0; j < msgPerShard; j++ {
 			b := fmt.Sprintf("foo%d-%d", i, j)
 			mm := producer.NewMockMessage(ctrl)
-			mm.EXPECT().Size().Return(uint32(len(b))).AnyTimes()
+			mm.EXPECT().Size().Return(len(b)).AnyTimes()
 			mm.EXPECT().Bytes().Return([]byte(b)).AnyTimes()
 			mm.EXPECT().Shard().Return(uint32(i)).AnyTimes()
 			mm.EXPECT().Finalize(producer.Consumed).Times(len(s.producers))

--- a/producer/buffer/buffer.go
+++ b/producer/buffer/buffer.go
@@ -72,7 +72,7 @@ type buffer struct {
 	buffers        *list.List
 	opts           Options
 	maxBufferSize  uint64
-	maxMessageSize uint32
+	maxMessageSize int
 	onFinalizeFn   producer.OnFinalizeFn
 	retrier        retry.Retrier
 	m              bufferMetrics
@@ -95,7 +95,7 @@ func NewBuffer(opts Options) (producer.Buffer, error) {
 	b := &buffer{
 		buffers:        list.New(),
 		maxBufferSize:  uint64(opts.MaxBufferSize()),
-		maxMessageSize: uint32(opts.MaxMessageSize()),
+		maxMessageSize: opts.MaxMessageSize(),
 		opts:           opts,
 		retrier:        retry.NewRetrier(opts.CleanupRetryOptions()),
 		m: newBufferMetrics(

--- a/producer/buffer/buffer_test.go
+++ b/producer/buffer/buffer_test.go
@@ -46,7 +46,7 @@ func TestBuffer(t *testing.T) {
 	defer ctrl.Finish()
 
 	mm := producer.NewMockMessage(ctrl)
-	mm.EXPECT().Size().Return(uint32(100)).AnyTimes()
+	mm.EXPECT().Size().Return(100).AnyTimes()
 
 	b := mustNewBuffer(t, testOptions())
 	require.Equal(t, 0, int(b.size.Load()))
@@ -54,7 +54,7 @@ func TestBuffer(t *testing.T) {
 
 	rm, err := b.Add(mm)
 	require.NoError(t, err)
-	require.Equal(t, uint64(mm.Size()), b.size.Load())
+	require.Equal(t, mm.Size(), int(b.size.Load()))
 
 	mm.EXPECT().Finalize(producer.Consumed)
 	// Finalize the message will reduce the buffer size.
@@ -68,7 +68,7 @@ func TestBufferAddMessageTooLarge(t *testing.T) {
 	defer ctrl.Finish()
 
 	mm := producer.NewMockMessage(ctrl)
-	mm.EXPECT().Size().Return(uint32(100)).AnyTimes()
+	mm.EXPECT().Size().Return(100).AnyTimes()
 
 	b := mustNewBuffer(t, NewOptions().SetMaxMessageSize(1))
 	_, err := b.Add(mm)
@@ -81,7 +81,7 @@ func TestBufferAddMessageLargerThanMaxBufferSize(t *testing.T) {
 	defer ctrl.Finish()
 
 	mm := producer.NewMockMessage(ctrl)
-	mm.EXPECT().Size().Return(uint32(100)).AnyTimes()
+	mm.EXPECT().Size().Return(100).AnyTimes()
 
 	b := mustNewBuffer(t, NewOptions().
 		SetMaxMessageSize(1).
@@ -97,12 +97,12 @@ func TestBufferCleanupEarliest(t *testing.T) {
 	defer ctrl.Finish()
 
 	mm := producer.NewMockMessage(ctrl)
-	mm.EXPECT().Size().Return(uint32(100)).AnyTimes()
+	mm.EXPECT().Size().Return(100).AnyTimes()
 
 	b := mustNewBuffer(t, NewOptions())
 	rm, err := b.Add(mm)
 	require.NoError(t, err)
-	require.Equal(t, rm.Size(), uint64(mm.Size()))
+	require.Equal(t, int(rm.Size()), mm.Size())
 	require.Equal(t, rm.Size(), b.size.Load())
 	require.Equal(t, 1, b.buffers.Len())
 
@@ -119,13 +119,13 @@ func TestCleanupBatch(t *testing.T) {
 	defer ctrl.Finish()
 
 	mm1 := producer.NewMockMessage(ctrl)
-	mm1.EXPECT().Size().Return(uint32(1)).AnyTimes()
+	mm1.EXPECT().Size().Return(1).AnyTimes()
 
 	mm2 := producer.NewMockMessage(ctrl)
-	mm2.EXPECT().Size().Return(uint32(2)).AnyTimes()
+	mm2.EXPECT().Size().Return(2).AnyTimes()
 
 	mm3 := producer.NewMockMessage(ctrl)
-	mm3.EXPECT().Size().Return(uint32(3)).AnyTimes()
+	mm3.EXPECT().Size().Return(3).AnyTimes()
 
 	b := mustNewBuffer(t, NewOptions().SetScanBatchSize(2))
 	_, err := b.Add(mm1)
@@ -158,13 +158,13 @@ func TestCleanupBatchWithElementBeingRemovedByOtherThread(t *testing.T) {
 	defer ctrl.Finish()
 
 	mm1 := producer.NewMockMessage(ctrl)
-	mm1.EXPECT().Size().Return(uint32(1)).AnyTimes()
+	mm1.EXPECT().Size().Return(1).AnyTimes()
 
 	mm2 := producer.NewMockMessage(ctrl)
-	mm2.EXPECT().Size().Return(uint32(2)).AnyTimes()
+	mm2.EXPECT().Size().Return(2).AnyTimes()
 
 	mm3 := producer.NewMockMessage(ctrl)
-	mm3.EXPECT().Size().Return(uint32(3)).AnyTimes()
+	mm3.EXPECT().Size().Return(3).AnyTimes()
 
 	b := mustNewBuffer(t, NewOptions())
 	_, err := b.Add(mm1)
@@ -216,7 +216,7 @@ func TestBufferCleanupBackground(t *testing.T) {
 	defer ctrl.Finish()
 
 	mm := producer.NewMockMessage(ctrl)
-	mm.EXPECT().Size().Return(uint32(100)).AnyTimes()
+	mm.EXPECT().Size().Return(100).AnyTimes()
 
 	b := mustNewBuffer(t, testOptions())
 	rm, err := b.Add(mm)
@@ -244,7 +244,7 @@ func TestListRemoveCleanupNextAndPrev(t *testing.T) {
 	defer ctrl.Finish()
 
 	mm := producer.NewMockMessage(ctrl)
-	mm.EXPECT().Size().Return(uint32(100)).AnyTimes()
+	mm.EXPECT().Size().Return(100).AnyTimes()
 
 	b := mustNewBuffer(t, NewOptions())
 	_, err := b.Add(mm)
@@ -270,7 +270,7 @@ func TestBufferCloseDropEverything(t *testing.T) {
 	defer ctrl.Finish()
 
 	mm := producer.NewMockMessage(ctrl)
-	mm.EXPECT().Size().Return(uint32(100)).AnyTimes()
+	mm.EXPECT().Size().Return(100).AnyTimes()
 
 	b := mustNewBuffer(t, testOptions())
 	rm, err := b.Add(mm)
@@ -297,7 +297,7 @@ func TestBufferDropEarliestOnFull(t *testing.T) {
 	defer ctrl.Finish()
 
 	mm := producer.NewMockMessage(ctrl)
-	mm.EXPECT().Size().Return(uint32(100)).AnyTimes()
+	mm.EXPECT().Size().Return(100).AnyTimes()
 
 	b := mustNewBuffer(t,
 		testOptions().
@@ -332,7 +332,7 @@ func TestBufferReturnErrorOnFull(t *testing.T) {
 	defer ctrl.Finish()
 
 	mm := producer.NewMockMessage(ctrl)
-	mm.EXPECT().Size().Return(uint32(100)).AnyTimes()
+	mm.EXPECT().Size().Return(100).AnyTimes()
 
 	b := mustNewBuffer(t, testOptions().
 		SetMaxMessageSize(int(mm.Size())).
@@ -371,7 +371,7 @@ func BenchmarkProduce(b *testing.B) {
 	defer ctrl.Finish()
 
 	mm := producer.NewMockMessage(ctrl)
-	mm.EXPECT().Size().Return(uint32(100)).AnyTimes()
+	mm.EXPECT().Size().Return(100).AnyTimes()
 	mm.EXPECT().Finalize(producer.Dropped).AnyTimes()
 
 	buffer := mustNewBuffer(b, NewOptions().

--- a/producer/producer_mock.go
+++ b/producer/producer_mock.go
@@ -78,9 +78,9 @@ func (_mr *_MockMessageRecorder) Shard() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Shard")
 }
 
-func (_m *MockMessage) Size() uint32 {
+func (_m *MockMessage) Size() int {
 	ret := _m.ctrl.Call(_m, "Size")
-	ret0, _ := ret[0].(uint32)
+	ret0, _ := ret[0].(int)
 	return ret0
 }
 

--- a/producer/ref_counted_test.go
+++ b/producer/ref_counted_test.go
@@ -34,11 +34,11 @@ func TestRefCountedMessageConsume(t *testing.T) {
 	defer ctrl.Finish()
 
 	mm := NewMockMessage(ctrl)
-	mm.EXPECT().Size().Return(uint32(100)).AnyTimes()
+	mm.EXPECT().Size().Return(100).AnyTimes()
 	mm.EXPECT().Finalize(Consumed)
 
 	rm := NewRefCountedMessage(mm, nil)
-	require.Equal(t, uint64(mm.Size()), rm.Size())
+	require.Equal(t, mm.Size(), int(rm.Size()))
 	require.False(t, rm.IsDroppedOrConsumed())
 
 	rm.IncRef()
@@ -58,11 +58,11 @@ func TestRefCountedMessageDrop(t *testing.T) {
 	defer ctrl.Finish()
 
 	mm := NewMockMessage(ctrl)
-	mm.EXPECT().Size().Return(uint32(100)).AnyTimes()
+	mm.EXPECT().Size().Return(100).AnyTimes()
 	mm.EXPECT().Finalize(Dropped)
 
 	rm := NewRefCountedMessage(mm, nil)
-	require.Equal(t, uint64(mm.Size()), rm.Size())
+	require.Equal(t, mm.Size(), int(rm.Size()))
 	require.False(t, rm.IsDroppedOrConsumed())
 
 	rm.Drop()
@@ -82,7 +82,7 @@ func TestRefCountedMessageBytesReadBlocking(t *testing.T) {
 
 	mm := NewMockMessage(ctrl)
 	mockBytes := []byte("foo")
-	mm.EXPECT().Size().Return(uint32(3))
+	mm.EXPECT().Size().Return(3)
 	mm.EXPECT().Bytes().Return(mockBytes)
 
 	rm := NewRefCountedMessage(mm, nil)
@@ -113,7 +113,7 @@ func TestRefCountedMessageDecPanic(t *testing.T) {
 	defer ctrl.Finish()
 
 	mm := NewMockMessage(ctrl)
-	mm.EXPECT().Size().Return(uint32(0))
+	mm.EXPECT().Size().Return(0)
 	rm := NewRefCountedMessage(mm, nil)
 	require.Panics(t, rm.DecRef)
 }
@@ -129,7 +129,7 @@ func TestRefCountedMessageFilter(t *testing.T) {
 	}
 
 	mm := NewMockMessage(ctrl)
-	mm.EXPECT().Size().Return(uint32(0))
+	mm.EXPECT().Size().Return(0)
 	rm := NewRefCountedMessage(mm, nil)
 
 	mm.EXPECT().Shard().Return(uint32(0))
@@ -144,7 +144,7 @@ func TestRefCountedMessageOnDropFn(t *testing.T) {
 	defer ctrl.Finish()
 
 	mm := NewMockMessage(ctrl)
-	mm.EXPECT().Size().Return(uint32(0))
+	mm.EXPECT().Size().Return(0)
 	mm.EXPECT().Finalize(Dropped)
 
 	var called int
@@ -164,7 +164,7 @@ func TestRefCountedMessageNoBlocking(t *testing.T) {
 	defer ctrl.Finish()
 
 	mm := NewMockMessage(ctrl)
-	mm.EXPECT().Size().Return(uint32(0)).AnyTimes()
+	mm.EXPECT().Size().Return(0).AnyTimes()
 	for i := 0; i < 10000; i++ {
 		rm := NewRefCountedMessage(mm, nil)
 		var wg sync.WaitGroup

--- a/producer/types.go
+++ b/producer/types.go
@@ -45,7 +45,7 @@ type Message interface {
 	Bytes() []byte
 
 	// Size returns the size of the bytes of the message.
-	Size() uint32
+	Size() int
 
 	// Finalize will be called by producer to indicate the end of its lifecycle.
 	Finalize(FinalizeReason)

--- a/producer/writer/consumer_service_writer_test.go
+++ b/producer/writer/consumer_service_writer_test.go
@@ -120,7 +120,7 @@ func TestConsumerServiceWriterWithSharedConsumerWithNonShardedPlacement(t *testi
 	mm := producer.NewMockMessage(ctrl)
 	mm.EXPECT().Shard().Return(uint32(1))
 	mm.EXPECT().Bytes().Return([]byte("foo"))
-	mm.EXPECT().Size().Return(uint32(3))
+	mm.EXPECT().Size().Return(3)
 	mm.EXPECT().Finalize(producer.Consumed)
 
 	rm := producer.NewRefCountedMessage(mm, nil)
@@ -256,7 +256,7 @@ func TestConsumerServiceWriterWithSharedConsumerWithShardedPlacement(t *testing.
 	mm := producer.NewMockMessage(ctrl)
 	mm.EXPECT().Shard().Return(uint32(1))
 	mm.EXPECT().Bytes().Return([]byte("foo"))
-	mm.EXPECT().Size().Return(uint32(3))
+	mm.EXPECT().Size().Return(3)
 	mm.EXPECT().Finalize(producer.Consumed)
 
 	rm := producer.NewRefCountedMessage(mm, nil)
@@ -381,7 +381,7 @@ func TestConsumerServiceWriterWithReplicatedConsumerWithShardedPlacement(t *test
 	mm := producer.NewMockMessage(ctrl)
 	mm.EXPECT().Shard().Return(uint32(1)).AnyTimes()
 	mm.EXPECT().Bytes().Return([]byte("foo")).AnyTimes()
-	mm.EXPECT().Size().Return(uint32(3))
+	mm.EXPECT().Size().Return(3)
 	mm.EXPECT().Finalize(producer.Consumed)
 
 	rm := producer.NewRefCountedMessage(mm, nil)
@@ -465,7 +465,7 @@ func TestConsumerServiceWriterWithReplicatedConsumerWithShardedPlacement(t *test
 	}()
 
 	mm.EXPECT().Finalize(producer.Consumed)
-	mm.EXPECT().Size().Return(uint32(3))
+	mm.EXPECT().Size().Return(3)
 	rm = producer.NewRefCountedMessage(mm, nil)
 	csw.Write(rm)
 	for {
@@ -502,10 +502,10 @@ func TestConsumerServiceWriterFilter(t *testing.T) {
 
 	mm0 := producer.NewMockMessage(ctrl)
 	mm0.EXPECT().Shard().Return(uint32(0)).AnyTimes()
-	mm0.EXPECT().Size().Return(uint32(3)).AnyTimes()
+	mm0.EXPECT().Size().Return(3).AnyTimes()
 	mm1 := producer.NewMockMessage(ctrl)
 	mm1.EXPECT().Shard().Return(uint32(1)).AnyTimes()
-	mm1.EXPECT().Size().Return(uint32(3)).AnyTimes()
+	mm1.EXPECT().Size().Return(3).AnyTimes()
 
 	sw0.EXPECT().Write(gomock.Any())
 	csw.Write(producer.NewRefCountedMessage(mm0, nil))
@@ -642,7 +642,7 @@ func TestConsumerServiceCloseShardWritersConcurrently(t *testing.T) {
 		mm := producer.NewMockMessage(ctrl)
 		mm.EXPECT().Shard().Return(i)
 		mm.EXPECT().Bytes().Return(b).AnyTimes()
-		mm.EXPECT().Size().Return(uint32(0)).AnyTimes()
+		mm.EXPECT().Size().Return(0).AnyTimes()
 		mm.EXPECT().Finalize(gomock.Any())
 		w.Write(producer.NewRefCountedMessage(mm, nil))
 	}

--- a/producer/writer/message_pool_test.go
+++ b/producer/writer/message_pool_test.go
@@ -39,7 +39,7 @@ func TestMessagePool(t *testing.T) {
 	defer ctrl.Finish()
 
 	mm := producer.NewMockMessage(ctrl)
-	mm.EXPECT().Size().Return(uint32(3))
+	mm.EXPECT().Size().Return(3)
 	rm := producer.NewRefCountedMessage(mm, nil)
 	rm.IncRef()
 
@@ -65,7 +65,7 @@ func TestMessagePool(t *testing.T) {
 	require.Nil(t, m.pb.Value)
 	require.True(t, m.IsDroppedOrConsumed())
 
-	mm.EXPECT().Size().Return(uint32(3))
+	mm.EXPECT().Size().Return(3)
 	mm.EXPECT().Bytes().Return([]byte("foo"))
 	m.Set(metadata{}, producer.NewRefCountedMessage(mm, nil))
 	require.False(t, m.IsDroppedOrConsumed())

--- a/producer/writer/message_writer_test.go
+++ b/producer/writer/message_writer_test.go
@@ -72,7 +72,7 @@ func TestMessageWriterWithPooling(t *testing.T) {
 
 	mm1 := producer.NewMockMessage(ctrl)
 	mm1.EXPECT().Bytes().Return([]byte("foo")).Times(1)
-	mm1.EXPECT().Size().Return(uint32(3)).Times(1)
+	mm1.EXPECT().Size().Return(3).Times(1)
 	mm1.EXPECT().Finalize(producer.Consumed)
 
 	w.Write(producer.NewRefCountedMessage(mm1, nil))
@@ -91,7 +91,7 @@ func TestMessageWriterWithPooling(t *testing.T) {
 
 	mm2 := producer.NewMockMessage(ctrl)
 	mm2.EXPECT().Bytes().Return([]byte("bar")).Times(1)
-	mm2.EXPECT().Size().Return(uint32(3)).Times(1)
+	mm2.EXPECT().Size().Return(3).Times(1)
 
 	w.Write(producer.NewRefCountedMessage(mm2, nil))
 	for {
@@ -155,7 +155,7 @@ func TestMessageWriterWithoutPooling(t *testing.T) {
 
 	mm1 := producer.NewMockMessage(ctrl)
 	mm1.EXPECT().Bytes().Return([]byte("foo")).Times(1)
-	mm1.EXPECT().Size().Return(uint32(3)).Times(1)
+	mm1.EXPECT().Size().Return(3).Times(1)
 	mm1.EXPECT().Finalize(producer.Consumed)
 
 	w.Write(producer.NewRefCountedMessage(mm1, nil))
@@ -174,7 +174,7 @@ func TestMessageWriterWithoutPooling(t *testing.T) {
 
 	mm2 := producer.NewMockMessage(ctrl)
 	mm2.EXPECT().Bytes().Return([]byte("bar")).Times(1)
-	mm2.EXPECT().Size().Return(uint32(3)).Times(1)
+	mm2.EXPECT().Size().Return(3).Times(1)
 
 	w.Write(producer.NewRefCountedMessage(mm2, nil))
 	for {
@@ -222,7 +222,7 @@ func TestMessageWriterRetryWithoutPooling(t *testing.T) {
 
 	mm := producer.NewMockMessage(ctrl)
 	mm.EXPECT().Bytes().Return([]byte("foo")).AnyTimes()
-	mm.EXPECT().Size().Return(uint32(3)).Times(1)
+	mm.EXPECT().Size().Return(3).Times(1)
 	mm.EXPECT().Finalize(producer.Consumed)
 
 	rm := producer.NewRefCountedMessage(mm, nil)
@@ -282,7 +282,7 @@ func TestMessageWriterRetryWithPooling(t *testing.T) {
 
 	mm := producer.NewMockMessage(ctrl)
 	mm.EXPECT().Bytes().Return([]byte("foo")).AnyTimes()
-	mm.EXPECT().Size().Return(uint32(3)).Times(1)
+	mm.EXPECT().Size().Return(3).Times(1)
 	mm.EXPECT().Finalize(producer.Consumed)
 
 	rm := producer.NewRefCountedMessage(mm, nil)
@@ -337,7 +337,7 @@ func TestMessageWriterCleanupDroppedMessage(t *testing.T) {
 
 	mm := producer.NewMockMessage(ctrl)
 
-	mm.EXPECT().Size().Return(uint32(3)).Times(1)
+	mm.EXPECT().Size().Return(3).Times(1)
 	rm := producer.NewRefCountedMessage(mm, nil)
 	mm.EXPECT().Finalize(producer.Dropped)
 	rm.Drop()
@@ -381,7 +381,7 @@ func TestMessageWriterCleanupAckedMessage(t *testing.T) {
 
 	mm := producer.NewMockMessage(ctrl)
 	mm.EXPECT().Bytes().Return([]byte("foo"))
-	mm.EXPECT().Size().Return(uint32(3)).Times(1)
+	mm.EXPECT().Size().Return(3).Times(1)
 
 	rm := producer.NewRefCountedMessage(mm, nil)
 	// Another message write also holds this message.
@@ -443,7 +443,7 @@ func TestMessageWriterCutoverCutoff(t *testing.T) {
 	require.Equal(t, 0, w.queue.Len())
 
 	mm := producer.NewMockMessage(ctrl)
-	mm.EXPECT().Size().Return(uint32(3))
+	mm.EXPECT().Size().Return(3)
 	w.Write(producer.NewRefCountedMessage(mm, nil))
 	require.Equal(t, 0, w.queue.Len())
 }
@@ -459,13 +459,13 @@ func TestMessageWriterRetryIterateBatch(t *testing.T) {
 	w := newMessageWriter(200, testMessagePool(opts), opts, testMessageWriterMetrics()).(*messageWriterImpl)
 
 	mm1 := producer.NewMockMessage(ctrl)
-	mm1.EXPECT().Size().Return(uint32(3))
+	mm1.EXPECT().Size().Return(3)
 	mm2 := producer.NewMockMessage(ctrl)
-	mm2.EXPECT().Size().Return(uint32(3))
+	mm2.EXPECT().Size().Return(3)
 	mm3 := producer.NewMockMessage(ctrl)
-	mm3.EXPECT().Size().Return(uint32(3))
+	mm3.EXPECT().Size().Return(3)
 	mm4 := producer.NewMockMessage(ctrl)
-	mm4.EXPECT().Size().Return(uint32(3))
+	mm4.EXPECT().Size().Return(3)
 	rm1 := producer.NewRefCountedMessage(mm1, nil)
 	rm2 := producer.NewRefCountedMessage(mm2, nil)
 	rm3 := producer.NewRefCountedMessage(mm3, nil)
@@ -542,7 +542,7 @@ func TestMessageWriterCloseCleanupAllMessages(t *testing.T) {
 	defer ctrl.Finish()
 
 	mm := producer.NewMockMessage(ctrl)
-	mm.EXPECT().Size().Return(uint32(3))
+	mm.EXPECT().Size().Return(3)
 
 	rm := producer.NewRefCountedMessage(mm, nil)
 	mm.EXPECT().Finalize(producer.Consumed)

--- a/producer/writer/shard_writer_test.go
+++ b/producer/writer/shard_writer_test.go
@@ -85,7 +85,7 @@ func TestSharedShardWriter(t *testing.T) {
 	mm := producer.NewMockMessage(ctrl)
 	mm.EXPECT().Bytes().Return([]byte("foo"))
 	mm.EXPECT().Finalize(producer.Consumed)
-	mm.EXPECT().Size().Return(uint32(3))
+	mm.EXPECT().Size().Return(3)
 
 	sw.Write(producer.NewRefCountedMessage(mm, nil))
 
@@ -167,7 +167,7 @@ func TestReplicatedShardWriter(t *testing.T) {
 	defer ctrl.Finish()
 
 	mm := producer.NewMockMessage(ctrl)
-	mm.EXPECT().Size().Return(uint32(3))
+	mm.EXPECT().Size().Return(3)
 	mm.EXPECT().Bytes().Return([]byte("foo")).Times(2)
 
 	sw.Write(producer.NewRefCountedMessage(mm, nil))
@@ -276,7 +276,7 @@ func TestReplicatedShardWriterRemoveMessageWriter(t *testing.T) {
 	defer ctrl.Finish()
 
 	mm := producer.NewMockMessage(ctrl)
-	mm.EXPECT().Size().Return(uint32(3))
+	mm.EXPECT().Size().Return(3)
 	mm.EXPECT().Bytes().Return([]byte("foo")).Times(2)
 
 	sw.Write(producer.NewRefCountedMessage(mm, nil))

--- a/producer/writer/writer_test.go
+++ b/producer/writer/writer_test.go
@@ -81,7 +81,7 @@ func TestWriterWriteAfterClosed(t *testing.T) {
 
 	mm := producer.NewMockMessage(ctrl)
 	mm.EXPECT().Finalize(producer.Dropped)
-	mm.EXPECT().Size().Return(uint32(3))
+	mm.EXPECT().Size().Return(3)
 	rm := producer.NewRefCountedMessage(mm, nil)
 	err = w.Write(rm)
 	require.Error(t, err)
@@ -108,14 +108,14 @@ func TestWriterWriteWithInvalidShard(t *testing.T) {
 	mm := producer.NewMockMessage(ctrl)
 	mm.EXPECT().Shard().Return(uint32(2))
 	mm.EXPECT().Finalize(producer.Dropped)
-	mm.EXPECT().Size().Return(uint32(3))
+	mm.EXPECT().Size().Return(3)
 	rm := producer.NewRefCountedMessage(mm, nil)
 	err = w.Write(rm)
 	require.Error(t, err)
 
 	mm.EXPECT().Shard().Return(uint32(100))
 	mm.EXPECT().Finalize(producer.Dropped)
-	mm.EXPECT().Size().Return(uint32(3))
+	mm.EXPECT().Size().Return(3)
 	rm = producer.NewRefCountedMessage(mm, nil)
 	err = w.Write(rm)
 	require.Error(t, err)
@@ -546,7 +546,7 @@ func TestWriterWrite(t *testing.T) {
 	var wg sync.WaitGroup
 	mm := producer.NewMockMessage(ctrl)
 	mm.EXPECT().Shard().Return(uint32(0)).Times(3)
-	mm.EXPECT().Size().Return(uint32(3))
+	mm.EXPECT().Size().Return(3)
 	mm.EXPECT().Bytes().Return([]byte("foo")).Times(3)
 	mm.EXPECT().Finalize(producer.Consumed).Do(func(interface{}) { wg.Done() })
 	rm := producer.NewRefCountedMessage(mm, nil)
@@ -623,7 +623,7 @@ func TestWriterCloseBlocking(t *testing.T) {
 	require.Equal(t, 1, len(w.consumerServiceWriters))
 
 	mm := producer.NewMockMessage(ctrl)
-	mm.EXPECT().Size().Return(uint32(3))
+	mm.EXPECT().Size().Return(3)
 	mm.EXPECT().Shard().Return(uint32(0)).Times(2)
 	mm.EXPECT().Bytes().Return([]byte("foo")).Times(1)
 	mm.EXPECT().Finalize(producer.Dropped)


### PR DESCRIPTION
Now that uint32 as message size don't really buy us anything, using int in the interface makes it easier for the user to implement the producer.Message interface and avoids some unnecessary type cast.

@xichen2020 @jeromefroe 