### PR TITLE
Use a separate go routine to drop earliest message

### DIFF
--- a/producer/buffer/buffer.go
+++ b/producer/buffer/buffer.go
@@ -347,6 +347,7 @@ func (b *buffer) Close(ct producer.CloseType) {
 	b.Unlock()
 	b.waitUntilAllDataConsumed()
 	close(b.doneCh)
+	close(b.dropEarliestCh)
 	b.wg.Wait()
 }
 

--- a/producer/buffer/options.go
+++ b/producer/buffer/options.go
@@ -35,6 +35,7 @@ const (
 	defaultDropEarliestInterval  = time.Second
 	defaultScanBatchSize         = 16
 	defaultCleanupInitialBackoff = 10 * time.Second
+	defaultAllowedSpilloverRatio = 0.2
 	defaultCleanupMaxBackoff     = time.Minute
 )
 
@@ -46,25 +47,27 @@ var (
 )
 
 type bufferOptions struct {
-	strategy             OnFullStrategy
-	maxBufferSize        int
-	maxMessageSize       int
-	closeCheckInterval   time.Duration
-	dropEarliestInterval time.Duration
-	scanBatchSize        int
-	rOpts                retry.Options
-	iOpts                instrument.Options
+	strategy              OnFullStrategy
+	maxBufferSize         int
+	maxMessageSize        int
+	closeCheckInterval    time.Duration
+	dropEarliestInterval  time.Duration
+	scanBatchSize         int
+	allowedSpilloverRatio float64
+	rOpts                 retry.Options
+	iOpts                 instrument.Options
 }
 
 // NewOptions creates Options.
 func NewOptions() Options {
 	return &bufferOptions{
-		strategy:             DropEarliest,
-		maxBufferSize:        defaultMaxBufferSize,
-		maxMessageSize:       defaultMaxMessageSize,
-		closeCheckInterval:   defaultCloseCheckInterval,
-		dropEarliestInterval: defaultDropEarliestInterval,
-		scanBatchSize:        defaultScanBatchSize,
+		strategy:              DropEarliest,
+		maxBufferSize:         defaultMaxBufferSize,
+		maxMessageSize:        defaultMaxMessageSize,
+		closeCheckInterval:    defaultCloseCheckInterval,
+		dropEarliestInterval:  defaultDropEarliestInterval,
+		scanBatchSize:         defaultScanBatchSize,
+		allowedSpilloverRatio: defaultAllowedSpilloverRatio,
 		rOpts: retry.NewOptions().
 			SetInitialBackoff(defaultCleanupInitialBackoff).
 			SetMaxBackoff(defaultCleanupMaxBackoff).
@@ -130,6 +133,16 @@ func (opts *bufferOptions) ScanBatchSize() int {
 func (opts *bufferOptions) SetScanBatchSize(value int) Options {
 	o := *opts
 	o.scanBatchSize = value
+	return &o
+}
+
+func (opts *bufferOptions) AllowedSpilloverRatio() float64 {
+	return opts.allowedSpilloverRatio
+}
+
+func (opts *bufferOptions) SetAllowedSpilloverRatio(value float64) Options {
+	o := *opts
+	o.allowedSpilloverRatio = value
 	return &o
 }
 

--- a/producer/buffer/options.go
+++ b/producer/buffer/options.go
@@ -32,7 +32,7 @@ const (
 	defaultMaxBufferSize         = 100 * 1024 * 1024 // 100MB.
 	defaultMaxMessageSize        = 1 * 1024 * 1024   // 1MB.
 	defaultCloseCheckInterval    = time.Second
-	defaultDropEarliestInterval  = time.Second
+	defaultDropOldestInterval    = time.Second
 	defaultScanBatchSize         = 16
 	defaultCleanupInitialBackoff = 10 * time.Second
 	defaultAllowedSpilloverRatio = 0.2
@@ -51,7 +51,7 @@ type bufferOptions struct {
 	maxBufferSize         int
 	maxMessageSize        int
 	closeCheckInterval    time.Duration
-	dropEarliestInterval  time.Duration
+	dropOldestInterval    time.Duration
 	scanBatchSize         int
 	allowedSpilloverRatio float64
 	rOpts                 retry.Options
@@ -61,11 +61,11 @@ type bufferOptions struct {
 // NewOptions creates Options.
 func NewOptions() Options {
 	return &bufferOptions{
-		strategy:              DropEarliest,
+		strategy:              DropOldest,
 		maxBufferSize:         defaultMaxBufferSize,
 		maxMessageSize:        defaultMaxMessageSize,
 		closeCheckInterval:    defaultCloseCheckInterval,
-		dropEarliestInterval:  defaultDropEarliestInterval,
+		dropOldestInterval:    defaultDropOldestInterval,
 		scanBatchSize:         defaultScanBatchSize,
 		allowedSpilloverRatio: defaultAllowedSpilloverRatio,
 		rOpts: retry.NewOptions().
@@ -116,13 +116,13 @@ func (opts *bufferOptions) SetCloseCheckInterval(value time.Duration) Options {
 	return &o
 }
 
-func (opts *bufferOptions) DropEarliestInterval() time.Duration {
-	return opts.dropEarliestInterval
+func (opts *bufferOptions) DropOldestInterval() time.Duration {
+	return opts.dropOldestInterval
 }
 
-func (opts *bufferOptions) SetDropEarliestInterval(value time.Duration) Options {
+func (opts *bufferOptions) SetDropOldestInterval(value time.Duration) Options {
 	o := *opts
-	o.dropEarliestInterval = value
+	o.dropOldestInterval = value
 	return &o
 }
 

--- a/producer/buffer/options.go
+++ b/producer/buffer/options.go
@@ -39,6 +39,7 @@ const (
 )
 
 var (
+	errInvalidScanBatchSize   = errors.New("invalid scan batch size")
 	errInvalidMaxMessageSize  = errors.New("invalid max message size")
 	errNegativeMaxBufferSize  = errors.New("negative max buffer size")
 	errNegativeMaxMessageSize = errors.New("negative max message size")
@@ -153,6 +154,9 @@ func (opts *bufferOptions) SetInstrumentOptions(value instrument.Options) Option
 }
 
 func (opts *bufferOptions) Validate() error {
+	if opts.ScanBatchSize() <= 0 {
+		return errInvalidScanBatchSize
+	}
 	if opts.MaxBufferSize() <= 0 {
 		return errNegativeMaxBufferSize
 	}

--- a/producer/buffer/strategy.go
+++ b/producer/buffer/strategy.go
@@ -25,7 +25,7 @@ import "fmt"
 var (
 	validStrategies = []OnFullStrategy{
 		ReturnError,
-		DropEarliest,
+		DropOldest,
 	}
 )
 

--- a/producer/buffer/strategy_test.go
+++ b/producer/buffer/strategy_test.go
@@ -35,9 +35,9 @@ func TestStrategyYamlUnmarshal(t *testing.T) {
 		expectedStrategy OnFullStrategy
 	}{
 		{
-			bytes:            []byte("dropEarliest"),
+			bytes:            []byte("dropOldest"),
 			expectErr:        false,
-			expectedStrategy: DropEarliest,
+			expectedStrategy: DropOldest,
 		},
 		{
 			bytes:            []byte("returnError"),

--- a/producer/buffer/types.go
+++ b/producer/buffer/types.go
@@ -67,6 +67,14 @@ type Options interface {
 	// SetCloseCheckInterval sets the close check interval.
 	SetCloseCheckInterval(value time.Duration) Options
 
+	// DropEarliestInterval returns the interval to drop earliest buffer.
+	// The max buffer size might be spilled over during the interval.
+	DropEarliestInterval() time.Duration
+
+	// SetDropEarliestInterval sets the interval to drop earliest buffer.
+	// The max buffer size might be spilled over during the interval.
+	SetDropEarliestInterval(value time.Duration) Options
+
 	// ScanBatchSize returns the scan batch size.
 	ScanBatchSize() int
 

--- a/producer/buffer/types.go
+++ b/producer/buffer/types.go
@@ -35,10 +35,10 @@ const (
 	// on new buffer requests when the buffer is full.
 	ReturnError OnFullStrategy = "returnError"
 
-	// DropEarliest means the earlist message in the buffer
+	// DropOldest means the oldest message in the buffer
 	// will be dropped to make room for new buffer requests
 	// when the buffer is full.
-	DropEarliest OnFullStrategy = "dropEarliest"
+	DropOldest OnFullStrategy = "dropOldest"
 )
 
 // Options configs the buffer.
@@ -67,13 +67,13 @@ type Options interface {
 	// SetCloseCheckInterval sets the close check interval.
 	SetCloseCheckInterval(value time.Duration) Options
 
-	// DropEarliestInterval returns the interval to drop earliest buffer.
+	// DropOldestInterval returns the interval to drop oldest buffer.
 	// The max buffer size might be spilled over during the interval.
-	DropEarliestInterval() time.Duration
+	DropOldestInterval() time.Duration
 
-	// SetDropEarliestInterval sets the interval to drop earliest buffer.
+	// SetDropOldestInterval sets the interval to drop oldest buffer.
 	// The max buffer size might be spilled over during the interval.
-	SetDropEarliestInterval(value time.Duration) Options
+	SetDropOldestInterval(value time.Duration) Options
 
 	// ScanBatchSize returns the scan batch size.
 	ScanBatchSize() int
@@ -82,9 +82,9 @@ type Options interface {
 	SetScanBatchSize(value int) Options
 
 	// AllowedSpilloverRatio returns the ratio for allowed buffer spill over,
-	// below which the buffer will drop earliest messages asynchronizely for
+	// below which the buffer will drop oldest messages asynchronizely for
 	// better performance. When the limit for allowed spill over is reached,
-	// the buffer will start to drop earliest messages synchronizely.
+	// the buffer will start to drop oldest messages synchronizely.
 	AllowedSpilloverRatio() float64
 
 	// SetAllowedSpilloverRatio sets the ratio for allowed buffer spill over.

--- a/producer/buffer/types.go
+++ b/producer/buffer/types.go
@@ -81,6 +81,15 @@ type Options interface {
 	// SetScanBatchSize sets the scan batch size.
 	SetScanBatchSize(value int) Options
 
+	// AllowedSpilloverRatio returns the ratio for allowed buffer spill over,
+	// below which the buffer will drop earliest messages asynchronizely for
+	// better performance. When the limit for allowed spill over is reached,
+	// the buffer will start to drop earliest messages synchronizely.
+	AllowedSpilloverRatio() float64
+
+	// SetAllowedSpilloverRatio sets the ratio for allowed buffer spill over.
+	SetAllowedSpilloverRatio(value float64) Options
+
 	// CleanupRetryOptions returns the cleanup retry options.
 	CleanupRetryOptions() retry.Options
 

--- a/producer/config/buffer.go
+++ b/producer/config/buffer.go
@@ -30,13 +30,14 @@ import (
 
 // BufferConfiguration configs the buffer.
 type BufferConfiguration struct {
-	OnFullStrategy       *buffer.OnFullStrategy `yaml:"onFullStrategy"`
-	MaxBufferSize        *int                   `yaml:"maxBufferSize"`
-	MaxMessageSize       *int                   `yaml:"maxMessageSize"`
-	CloseCheckInterval   *time.Duration         `yaml:"closeCheckInterval"`
-	DropEarliestInterval *time.Duration         `yaml:"dropEarliestInterval"`
-	ScanBatchSize        *int                   `yaml:"scanBatchSize"`
-	CleanupRetry         *retry.Configuration   `yaml:"cleanupRetry"`
+	OnFullStrategy        *buffer.OnFullStrategy `yaml:"onFullStrategy"`
+	MaxBufferSize         *int                   `yaml:"maxBufferSize"`
+	MaxMessageSize        *int                   `yaml:"maxMessageSize"`
+	CloseCheckInterval    *time.Duration         `yaml:"closeCheckInterval"`
+	DropEarliestInterval  *time.Duration         `yaml:"dropEarliestInterval"`
+	ScanBatchSize         *int                   `yaml:"scanBatchSize"`
+	AllowedSpilloverRatio *float64               `yaml:"allowedSpilloverRatio"`
+	CleanupRetry          *retry.Configuration   `yaml:"cleanupRetry"`
 }
 
 // NewOptions creates new buffer options.
@@ -54,11 +55,14 @@ func (c *BufferConfiguration) NewOptions(iOpts instrument.Options) buffer.Option
 	if c.OnFullStrategy != nil {
 		opts = opts.SetOnFullStrategy(*c.OnFullStrategy)
 	}
+	if c.DropEarliestInterval != nil {
+		opts = opts.SetDropEarliestInterval(*c.DropEarliestInterval)
+	}
 	if c.ScanBatchSize != nil {
 		opts = opts.SetScanBatchSize(*c.ScanBatchSize)
 	}
-	if c.DropEarliestInterval != nil {
-		opts = opts.SetDropEarliestInterval(*c.DropEarliestInterval)
+	if c.AllowedSpilloverRatio != nil {
+		opts = opts.SetAllowedSpilloverRatio(*c.AllowedSpilloverRatio)
 	}
 	if c.CleanupRetry != nil {
 		opts = opts.SetCleanupRetryOptions(c.CleanupRetry.NewOptions(iOpts.MetricsScope()))

--- a/producer/config/buffer.go
+++ b/producer/config/buffer.go
@@ -30,12 +30,13 @@ import (
 
 // BufferConfiguration configs the buffer.
 type BufferConfiguration struct {
-	OnFullStrategy     *buffer.OnFullStrategy `yaml:"onFullStrategy"`
-	MaxBufferSize      *int                   `yaml:"maxBufferSize"`
-	MaxMessageSize     *int                   `yaml:"maxMessageSize"`
-	CloseCheckInterval *time.Duration         `yaml:"closeCheckInterval"`
-	ScanBatchSize      *int                   `yaml:"scanBatchSize"`
-	CleanupRetry       *retry.Configuration   `yaml:"cleanupRetry"`
+	OnFullStrategy       *buffer.OnFullStrategy `yaml:"onFullStrategy"`
+	MaxBufferSize        *int                   `yaml:"maxBufferSize"`
+	MaxMessageSize       *int                   `yaml:"maxMessageSize"`
+	CloseCheckInterval   *time.Duration         `yaml:"closeCheckInterval"`
+	DropEarliestInterval *time.Duration         `yaml:"dropEarliestInterval"`
+	ScanBatchSize        *int                   `yaml:"scanBatchSize"`
+	CleanupRetry         *retry.Configuration   `yaml:"cleanupRetry"`
 }
 
 // NewOptions creates new buffer options.
@@ -55,6 +56,9 @@ func (c *BufferConfiguration) NewOptions(iOpts instrument.Options) buffer.Option
 	}
 	if c.ScanBatchSize != nil {
 		opts = opts.SetScanBatchSize(*c.ScanBatchSize)
+	}
+	if c.DropEarliestInterval != nil {
+		opts = opts.SetDropEarliestInterval(*c.DropEarliestInterval)
 	}
 	if c.CleanupRetry != nil {
 		opts = opts.SetCleanupRetryOptions(c.CleanupRetry.NewOptions(iOpts.MetricsScope()))

--- a/producer/config/buffer.go
+++ b/producer/config/buffer.go
@@ -34,7 +34,7 @@ type BufferConfiguration struct {
 	MaxBufferSize         *int                   `yaml:"maxBufferSize"`
 	MaxMessageSize        *int                   `yaml:"maxMessageSize"`
 	CloseCheckInterval    *time.Duration         `yaml:"closeCheckInterval"`
-	DropEarliestInterval  *time.Duration         `yaml:"dropEarliestInterval"`
+	DropOldestInterval    *time.Duration         `yaml:"dropOldestInterval"`
 	ScanBatchSize         *int                   `yaml:"scanBatchSize"`
 	AllowedSpilloverRatio *float64               `yaml:"allowedSpilloverRatio"`
 	CleanupRetry          *retry.Configuration   `yaml:"cleanupRetry"`
@@ -42,7 +42,7 @@ type BufferConfiguration struct {
 
 // NewOptions creates new buffer options.
 func (c *BufferConfiguration) NewOptions(iOpts instrument.Options) buffer.Options {
-	opts := buffer.NewOptions().SetOnFullStrategy(buffer.DropEarliest)
+	opts := buffer.NewOptions().SetOnFullStrategy(buffer.DropOldest)
 	if c.MaxBufferSize != nil {
 		opts = opts.SetMaxBufferSize(*c.MaxBufferSize)
 	}
@@ -55,8 +55,8 @@ func (c *BufferConfiguration) NewOptions(iOpts instrument.Options) buffer.Option
 	if c.OnFullStrategy != nil {
 		opts = opts.SetOnFullStrategy(*c.OnFullStrategy)
 	}
-	if c.DropEarliestInterval != nil {
-		opts = opts.SetDropEarliestInterval(*c.DropEarliestInterval)
+	if c.DropOldestInterval != nil {
+		opts = opts.SetDropOldestInterval(*c.DropOldestInterval)
 	}
 	if c.ScanBatchSize != nil {
 		opts = opts.SetScanBatchSize(*c.ScanBatchSize)

--- a/producer/config/buffer_test.go
+++ b/producer/config/buffer_test.go
@@ -39,7 +39,7 @@ maxBufferSize: 100
 maxMessageSize: 16
 closeCheckInterval: 3s
 scanBatchSize: 128
-dropEarliestInterval: 500ms
+dropOldestInterval: 500ms
 allowedSpilloverRatio: 0.1
 cleanupRetry:
   initialBackoff: 2s
@@ -54,7 +54,7 @@ cleanupRetry:
 	require.Equal(t, 16, bOpts.MaxMessageSize())
 	require.Equal(t, 3*time.Second, bOpts.CloseCheckInterval())
 	require.Equal(t, 128, bOpts.ScanBatchSize())
-	require.Equal(t, 500*time.Millisecond, bOpts.DropEarliestInterval())
+	require.Equal(t, 500*time.Millisecond, bOpts.DropOldestInterval())
 	require.Equal(t, 0.1, bOpts.AllowedSpilloverRatio())
 	require.Equal(t, 2*time.Second, bOpts.CleanupRetryOptions().InitialBackoff())
 }

--- a/producer/config/buffer_test.go
+++ b/producer/config/buffer_test.go
@@ -39,6 +39,7 @@ maxBufferSize: 100
 maxMessageSize: 16
 closeCheckInterval: 3s
 scanBatchSize: 128
+dropEarliestInterval: 500ms
 cleanupRetry:
   initialBackoff: 2s
 `
@@ -50,9 +51,10 @@ cleanupRetry:
 	require.Equal(t, buffer.ReturnError, bOpts.OnFullStrategy())
 	require.Equal(t, 100, bOpts.MaxBufferSize())
 	require.Equal(t, 16, bOpts.MaxMessageSize())
-	require.Equal(t, 2*time.Second, bOpts.CleanupRetryOptions().InitialBackoff())
 	require.Equal(t, 3*time.Second, bOpts.CloseCheckInterval())
 	require.Equal(t, 128, bOpts.ScanBatchSize())
+	require.Equal(t, 500*time.Millisecond, bOpts.DropEarliestInterval())
+	require.Equal(t, 2*time.Second, bOpts.CleanupRetryOptions().InitialBackoff())
 }
 
 func TestEmptyBufferConfiguration(t *testing.T) {

--- a/producer/config/buffer_test.go
+++ b/producer/config/buffer_test.go
@@ -40,6 +40,7 @@ maxMessageSize: 16
 closeCheckInterval: 3s
 scanBatchSize: 128
 dropEarliestInterval: 500ms
+allowedSpilloverRatio: 0.1
 cleanupRetry:
   initialBackoff: 2s
 `
@@ -54,6 +55,7 @@ cleanupRetry:
 	require.Equal(t, 3*time.Second, bOpts.CloseCheckInterval())
 	require.Equal(t, 128, bOpts.ScanBatchSize())
 	require.Equal(t, 500*time.Millisecond, bOpts.DropEarliestInterval())
+	require.Equal(t, 0.1, bOpts.AllowedSpilloverRatio())
 	require.Equal(t, 2*time.Second, bOpts.CleanupRetryOptions().InitialBackoff())
 }
 

--- a/producer/ref_counted.go
+++ b/producer/ref_counted.go
@@ -100,6 +100,8 @@ func (rm *RefCountedMessage) IsDroppedOrConsumed() bool {
 }
 
 func (rm *RefCountedMessage) finalize(r FinalizeReason) bool {
+	// NB: This lock prevents the message from being finalized when its still
+	// being read.
 	rm.Lock()
 	if rm.isDroppedOrConsumed.Load() {
 		rm.Unlock()


### PR DESCRIPTION
Use a separate go routine to drop earliest messages in the buffer, this removes the expensive message close from the hot path for buffer add when the buffer is full

@xichen2020 @jeromefroe 