### PR TITLE
Add a flush interval for buffered writer

### DIFF
--- a/integration/setup.go
+++ b/integration/setup.go
@@ -554,7 +554,8 @@ writer:
     retry:
       initialBackoff: 20ms
       maxBackoff: 50ms
-    writeBufferSize: 128
+    flushInterval: 50ms
+    writeBufferSize: 4096
     resetDelay: 50ms
 `
 

--- a/producer/config/writer.go
+++ b/producer/config/writer.go
@@ -41,6 +41,7 @@ type ConnectionConfiguration struct {
 	KeepAlivePeriod *time.Duration       `yaml:"keepAlivePeriod"`
 	ResetDelay      *time.Duration       `yaml:"resetDelay"`
 	Retry           *retry.Configuration `yaml:"retry"`
+	FlushInterval   *time.Duration       `yaml:"flushInterval"`
 	WriteBufferSize *int                 `yaml:"writeBufferSize"`
 	ReadBufferSize  *int                 `yaml:"readBufferSize"`
 }
@@ -62,6 +63,9 @@ func (c *ConnectionConfiguration) NewOptions(iOpts instrument.Options) writer.Co
 	}
 	if c.Retry != nil {
 		opts = opts.SetRetryOptions(c.Retry.NewOptions(iOpts.MetricsScope()))
+	}
+	if c.FlushInterval != nil {
+		opts = opts.SetFlushInterval(*c.FlushInterval)
 	}
 	if c.WriteBufferSize != nil {
 		opts = opts.SetWriteBufferSize(*c.WriteBufferSize)

--- a/producer/config/writer_test.go
+++ b/producer/config/writer_test.go
@@ -43,6 +43,7 @@ resetDelay: 1s
 retry:
   initialBackoff: 1ms
   maxBackoff: 2ms
+flushInterval: 2s
 writeBufferSize: 100
 readBufferSize: 200
 `
@@ -57,6 +58,7 @@ readBufferSize: 200
 	require.Equal(t, time.Second, cOpts.ResetDelay())
 	require.Equal(t, time.Millisecond, cOpts.RetryOptions().InitialBackoff())
 	require.Equal(t, 2*time.Millisecond, cOpts.RetryOptions().MaxBackoff())
+	require.Equal(t, 2*time.Second, cOpts.FlushInterval())
 	require.Equal(t, 100, cOpts.WriteBufferSize())
 	require.Equal(t, 200, cOpts.ReadBufferSize())
 }

--- a/producer/writer/message_writer.go
+++ b/producer/writer/message_writer.go
@@ -280,7 +280,7 @@ func (w *messageWriterImpl) Init() {
 func (w *messageWriterImpl) scanMessageQueueUntilClose() {
 	var (
 		interval = w.opts.MessageQueueScanInterval()
-		jitter   = time.Duration(rand.Int63n(int64(interval)))
+		jitter   = time.Duration(w.r.Int63n(int64(interval)))
 	)
 	// NB(cw): Add some jitter before the tick starts to reduce
 	// some contention between all the message writers.

--- a/producer/writer/options.go
+++ b/producer/writer/options.go
@@ -42,6 +42,7 @@ const (
 	defaultMessageQueueScanInterval  = time.Second
 	defaultMessageQueueScanBatchSize = 16
 	defaultInitialAckMapSize         = 1024
+	defaultConnectionFlushInterval   = time.Second
 	// Using 16K which provides much better performance comparing
 	// to lower values like 1k ~ 8k.
 	defaultConnectionBufferSize = 16384
@@ -79,6 +80,12 @@ type ConnectionOptions interface {
 	// SetRetryOptions sets the options for connection retrier.
 	SetRetryOptions(value retry.Options) ConnectionOptions
 
+	// FlushInterval returns the interval for flushing the buffered bytes.
+	FlushInterval() time.Duration
+
+	// SetFlushInterval sets the interval for flushing the buffered bytes.
+	SetFlushInterval(value time.Duration) ConnectionOptions
+
 	// WriteBufferSize returns the buffer size for write.
 	WriteBufferSize() int
 
@@ -104,6 +111,7 @@ type connectionOptions struct {
 	keepAlivePeriod time.Duration
 	resetDelay      time.Duration
 	rOpts           retry.Options
+	flushInterval   time.Duration
 	writeBufferSize int
 	readBufferSize  int
 	iOpts           instrument.Options
@@ -117,6 +125,7 @@ func NewConnectionOptions() ConnectionOptions {
 		keepAlivePeriod: defaultKeepAlivePeriod,
 		resetDelay:      defaultConnectionResetDelay,
 		rOpts:           retry.NewOptions(),
+		flushInterval:   defaultConnectionFlushInterval,
 		writeBufferSize: defaultConnectionBufferSize,
 		readBufferSize:  defaultConnectionBufferSize,
 		iOpts:           instrument.NewOptions(),
@@ -170,6 +179,16 @@ func (opts *connectionOptions) ResetDelay() time.Duration {
 func (opts *connectionOptions) SetResetDelay(value time.Duration) ConnectionOptions {
 	o := *opts
 	o.resetDelay = value
+	return &o
+}
+
+func (opts *connectionOptions) FlushInterval() time.Duration {
+	return opts.flushInterval
+}
+
+func (opts *connectionOptions) SetFlushInterval(value time.Duration) ConnectionOptions {
+	o := *opts
+	o.flushInterval = value
 	return &o
 }
 

--- a/producer/writer/options_test.go
+++ b/producer/writer/options_test.go
@@ -70,6 +70,9 @@ func TestConnectionOptions(t *testing.T) {
 
 	require.Nil(t, opts.SetRetryOptions(nil).RetryOptions())
 
+	require.Equal(t, defaultConnectionFlushInterval, opts.FlushInterval())
+	require.Equal(t, 2*time.Second, opts.SetFlushInterval(2*time.Second).FlushInterval())
+
 	require.Equal(t, defaultConnectionBufferSize, opts.WriteBufferSize())
 	require.Equal(t, 1, opts.SetWriteBufferSize(1).WriteBufferSize())
 


### PR DESCRIPTION
Previously flush was only called when the buffer size was reached, there could cause a message to be buffered but not flushed because it's waiting for the buffer to fill up, especially in a case when the message incoming rate is uneven, e.g, in every 10s, most messages came in the first 1-2s, then it rapidly ramps down and reaches barely nothing in the last 1-2s. So some messages during the times when the incoming rate is low could wait a while for the next message to come in and push it out.

This pr adds a time based flush which limits the wait time for such cases.

This also allows us to use a much larger buffer size, like 16k to gain much better write performance in the spiky times where the incoming rate is very high.

@xichen2020 