### PR TITLE
Separate queue scans for new messages and retries

### DIFF
--- a/integration/setup.go
+++ b/integration/setup.go
@@ -543,7 +543,8 @@ writer:
   messageRetry:
     initialBackoff: 20ms
     maxBackoff: 50ms
-  messageQueueScanInterval: 10ms
+  messageQueueNewWritesScanInterval: 10ms
+  messageQueueFullScanInterval: 50ms
   closeCheckInterval: 200ms
   ackErrorRetry: 
     initialBackoff: 20ms

--- a/producer/config/writer.go
+++ b/producer/config/writer.go
@@ -78,20 +78,21 @@ func (c *ConnectionConfiguration) NewOptions(iOpts instrument.Options) writer.Co
 
 // WriterConfiguration configs the writer options.
 type WriterConfiguration struct {
-	TopicName                 string                            `yaml:"topicName" validate:"nonzero"`
-	TopicServiceOverride      kv.OverrideConfiguration          `yaml:"topicServiceOverride"`
-	TopicWatchInitTimeout     *time.Duration                    `yaml:"topicWatchInitTimeout"`
-	PlacementServiceOverride  services.OverrideConfiguration    `yaml:"placementServiceOverride"`
-	PlacementWatchInitTimeout *time.Duration                    `yaml:"placementWatchInitTimeout"`
-	MessagePool               *pool.ObjectPoolConfiguration     `yaml:"messagePool"`
-	MessageRetry              *retry.Configuration              `yaml:"messageRetry"`
-	MessageQueueScanInterval  *time.Duration                    `yaml:"messageQueueScanInterval"`
-	MessageQueueScanBatchSize *int                              `yaml:"messageQueueScanBatchSize"`
-	InitialAckMapSize         *int                              `yaml:"initialAckMapSize"`
-	CloseCheckInterval        *time.Duration                    `yaml:"closeCheckInterval"`
-	AckErrorRetry             *retry.Configuration              `yaml:"ackErrorRetry"`
-	EncodeDecoder             *proto.EncodeDecoderConfiguration `yaml:"encodeDecoder"`
-	Connection                *ConnectionConfiguration          `yaml:"connection"`
+	TopicName                         string                            `yaml:"topicName" validate:"nonzero"`
+	TopicServiceOverride              kv.OverrideConfiguration          `yaml:"topicServiceOverride"`
+	TopicWatchInitTimeout             *time.Duration                    `yaml:"topicWatchInitTimeout"`
+	PlacementServiceOverride          services.OverrideConfiguration    `yaml:"placementServiceOverride"`
+	PlacementWatchInitTimeout         *time.Duration                    `yaml:"placementWatchInitTimeout"`
+	MessagePool                       *pool.ObjectPoolConfiguration     `yaml:"messagePool"`
+	MessageRetry                      *retry.Configuration              `yaml:"messageRetry"`
+	MessageQueueNewWritesScanInterval *time.Duration                    `yaml:"messageQueueNewWritesScanInterval"`
+	MessageQueueFullScanInterval      *time.Duration                    `yaml:"messageQueueFullScanInterval"`
+	MessageQueueScanBatchSize         *int                              `yaml:"messageQueueScanBatchSize"`
+	InitialAckMapSize                 *int                              `yaml:"initialAckMapSize"`
+	CloseCheckInterval                *time.Duration                    `yaml:"closeCheckInterval"`
+	AckErrorRetry                     *retry.Configuration              `yaml:"ackErrorRetry"`
+	EncodeDecoder                     *proto.EncodeDecoderConfiguration `yaml:"encodeDecoder"`
+	Connection                        *ConnectionConfiguration          `yaml:"connection"`
 }
 
 // NewOptions creates writer options.
@@ -130,8 +131,11 @@ func (c *WriterConfiguration) NewOptions(
 	if c.MessageRetry != nil {
 		opts = opts.SetMessageRetryOptions(c.MessageRetry.NewOptions(iOpts.MetricsScope()))
 	}
-	if c.MessageQueueScanInterval != nil {
-		opts = opts.SetMessageQueueScanInterval(*c.MessageQueueScanInterval)
+	if c.MessageQueueNewWritesScanInterval != nil {
+		opts = opts.SetMessageQueueNewWritesScanInterval(*c.MessageQueueNewWritesScanInterval)
+	}
+	if c.MessageQueueFullScanInterval != nil {
+		opts = opts.SetMessageQueueFullScanInterval(*c.MessageQueueFullScanInterval)
 	}
 	if c.MessageQueueScanBatchSize != nil {
 		opts = opts.SetMessageQueueScanBatchSize(*c.MessageQueueScanBatchSize)

--- a/producer/config/writer_test.go
+++ b/producer/config/writer_test.go
@@ -78,7 +78,8 @@ messagePool:
   size: 5
 messageRetry:
   initialBackoff: 1ms
-messageQueueScanInterval: 5s
+messageQueueNewWritesScanInterval: 200ms
+messageQueueFullScanInterval: 10s
 messageQueueScanBatchSize: 1024
 initialAckMapSize: 1024
 closeCheckInterval: 2s
@@ -108,7 +109,8 @@ connection:
 	require.Equal(t, 2*time.Second, wOpts.PlacementWatchInitTimeout())
 	require.Equal(t, 5, wOpts.MessagePoolOptions().Size())
 	require.Equal(t, time.Millisecond, wOpts.MessageRetryOptions().InitialBackoff())
-	require.Equal(t, 5*time.Second, wOpts.MessageQueueScanInterval())
+	require.Equal(t, 200*time.Millisecond, wOpts.MessageQueueNewWritesScanInterval())
+	require.Equal(t, 10*time.Second, wOpts.MessageQueueFullScanInterval())
 	require.Equal(t, 1024, wOpts.MessageQueueScanBatchSize())
 	require.Equal(t, 1024, wOpts.InitialAckMapSize())
 	require.Equal(t, 2*time.Second, wOpts.CloseCheckInterval())

--- a/producer/writer/consumer_writer_test.go
+++ b/producer/writer/consumer_writer_test.go
@@ -357,7 +357,8 @@ func testOptions() Options {
 		SetTopicWatchInitTimeout(100 * time.Millisecond).
 		SetPlacementWatchInitTimeout(100 * time.Millisecond).
 		SetMessagePoolOptions(pool.NewObjectPoolOptions().SetSize(1)).
-		SetMessageQueueScanInterval(100 * time.Millisecond).
+		SetMessageQueueNewWritesScanInterval(100 * time.Millisecond).
+		SetMessageQueueFullScanInterval(200 * time.Millisecond).
 		SetMessageRetryOptions(retry.NewOptions().SetInitialBackoff(100 * time.Millisecond).SetMaxBackoff(500 * time.Millisecond)).
 		SetAckErrorRetryOptions(retry.NewOptions().SetInitialBackoff(200 * time.Millisecond).SetMaxBackoff(time.Second)).
 		SetConnectionOptions(testConnectionOptions())

--- a/producer/writer/options_test.go
+++ b/producer/writer/options_test.go
@@ -41,8 +41,11 @@ func TestOptions(t *testing.T) {
 	require.Equal(t, defaultPlacementWatchInitTimeout, opts.PlacementWatchInitTimeout())
 	require.Equal(t, time.Second, opts.SetPlacementWatchInitTimeout(time.Second).PlacementWatchInitTimeout())
 
-	require.Equal(t, defaultMessageQueueScanInterval, opts.MessageQueueScanInterval())
-	require.Equal(t, time.Second, opts.SetMessageQueueScanInterval(time.Second).MessageQueueScanInterval())
+	require.Equal(t, defaultMessageQueueNewWritesScanInterval, opts.MessageQueueNewWritesScanInterval())
+	require.Equal(t, time.Second, opts.SetMessageQueueNewWritesScanInterval(time.Second).MessageQueueNewWritesScanInterval())
+
+	require.Equal(t, defaultMessageQueueFullScanInterval, opts.MessageQueueFullScanInterval())
+	require.Equal(t, time.Minute, opts.SetMessageQueueFullScanInterval(time.Minute).MessageQueueFullScanInterval())
 
 	require.Nil(t, opts.MessagePoolOptions())
 


### PR DESCRIPTION
This diff separate the types of queue scans to allow more frequent and cheaper scanning for new messages and occasionally full scan to look for possible retry opportunities and remove acked message from the queue. 
The messages were finalized as soon as they were acked, so this is only delaying their removal from the queue.

@xichen2020 